### PR TITLE
errors: rename FileLocation to the more idiomatic Caller.

### DIFF
--- a/errors/caller.go
+++ b/errors/caller.go
@@ -57,13 +57,13 @@ func (ae *annotated) Format(f fmt.State, c rune) {
 	fmt.Fprintf(f, format, ae.annotation, ae.err)
 }
 
-// FileLocation returns the callers location as a filepath and line
+// Caller returns the caller's location as a filepath and line
 // number. Depth follows the convention for runtime.Caller. The
 // filepath is the trailing nameLen components of the filename
 // returned by runtime.Caller. A nameLen of 2 is generally the
 // best compromise between brevity and precision since it includes
 // the enclosing directory component as well as the filename.
-func FileLocation(depth, nameLen int) string {
+func Caller(depth, nameLen int) string {
 	_, file, line, _ := runtime.Caller(depth)
 	if nameLen <= 1 {
 		return filepath.Base(file) + ":" + strconv.Itoa(line)
@@ -83,15 +83,15 @@ func FileLocation(depth, nameLen int) string {
 	return base + ":" + strconv.Itoa(line)
 }
 
-// Caller returns an error annotated with the location of its immediate caller.
-func Caller(err error) error {
-	return Annotate(FileLocation(2, 2), err)
+// WithCaller returns an error annotated with the location of its immediate caller.
+func WithCaller(err error) error {
+	return Annotate(Caller(2, 2), err)
 }
 
-// CallerAll returns a slice conntaing annotated versions of all of the
+// WithCallerAll returns a slice conntaing annotated versions of all of the
 // supplied errors.
-func CallerAll(err ...error) []error {
-	return AnnotateAll(FileLocation(2, 2), err...)
+func WithCallerAll(err ...error) []error {
+	return AnnotateAll(Caller(2, 2), err...)
 }
 
 // Annotate returns an error representing the original error and the

--- a/errors/caller_test.go
+++ b/errors/caller_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func ExampleCaller() {
-	err := errors.Caller(os.ErrNotExist)
+	err := errors.WithCaller(os.ErrNotExist)
 	fmt.Printf("%v\n", err)
 	fmt.Printf("%v\n", errors.Unwrap(err))
 	// Output:
@@ -24,8 +24,8 @@ func ExampleCaller() {
 
 func ExampleM_caller() {
 	m := &errors.M{}
-	m.Append(errors.Caller(os.ErrExist))
-	m.Append(errors.Caller(os.ErrInvalid))
+	m.Append(errors.WithCaller(os.ErrExist))
+	m.Append(errors.WithCaller(os.ErrInvalid))
 	fmt.Println(m.Err())
 	// Output:
 	//   --- 1 of 2 errors
@@ -35,8 +35,8 @@ func ExampleM_caller() {
 }
 
 func ExampleFileLocation() {
-	fmt.Println(errors.FileLocation(1, 1))
-	fmt.Println(errors.FileLocation(1, 2))
+	fmt.Println(errors.Caller(1, 1))
+	fmt.Println(errors.Caller(1, 2))
 	// Output:
 	// caller_test.go:38
 	// errors/caller_test.go:39
@@ -48,7 +48,7 @@ func TestAnnotated(t *testing.T) {
 		Path: "/a/b",
 		Err:  os.ErrNotExist,
 	}
-	err := errors.Caller(myErr)
+	err := errors.WithCaller(myErr)
 	if got, want := err.Error(), "errors/caller_test.go:51: open /a/b: file does not exist"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
@@ -75,7 +75,7 @@ func TestAnnotated(t *testing.T) {
 }
 
 func TestPrintf(t *testing.T) {
-	err := errors.Caller(&os.PathError{
+	err := errors.WithCaller(&os.PathError{
 		Op:   "open",
 		Path: "/a/b",
 		Err:  os.ErrNotExist,

--- a/errors/caller_test.go
+++ b/errors/caller_test.go
@@ -13,7 +13,7 @@ import (
 	"cloudeng.io/errors"
 )
 
-func ExampleCaller() {
+func ExampleWithCaller() {
 	err := errors.WithCaller(os.ErrNotExist)
 	fmt.Printf("%v\n", err)
 	fmt.Printf("%v\n", errors.Unwrap(err))
@@ -34,7 +34,7 @@ func ExampleM_caller() {
 	//   errors/caller_test.go:28: invalid argument
 }
 
-func ExampleFileLocation() {
+func ExampleCaller() {
 	fmt.Println(errors.Caller(1, 1))
 	fmt.Println(errors.Caller(1, 2))
 	// Output:

--- a/errors/doc.go
+++ b/errors/doc.go
@@ -3,19 +3,23 @@
 // license that can be found in the LICENSE file.
 
 // Package errors provides utility routines for working with errors that
-// are compatible with go 1.13+ and for annotating errors with location
-// and other information. It provides errors.M which can be used
-// to collect and work with multiple errors in a thread safe manner.
-// It also provides convenience routines for annotating existing errors
-// with caller and other information.
+// are compatible with go 1.13+ and for annotating errors. It provides
+// errors.M which can be used to collect and work with multiple errors in a
+// thread safe manner. It also provides convenience routines for annotating
+// existing errors with caller and other information.
 //
 //   errs := errors.M{}
 //   errs.Append(fn(a))
 //   errs.Append(fn(b))
 //   err := errs.Err()
 //
+//
+// The location of a function's immediate caller (depth of 1) in form of the
+// directory/filename:<line> (name len of 2) can be obtained as follows:
+//   errors.Caller(1, 2)
+//
 // Annotations, can be added as follows:
-//   err := errors.Caller(os.ErrNotExist)
+//   err := errors.WithCaller(os.ErrNotExist)
 //
 // Where:
 //   fmt.Printf("%v\n", err)
@@ -27,8 +31,8 @@
 //
 // Annotated errors can be passed to errors.M:
 //   errs := errors.M{}
-//   errs.Append(errors.Caller(fn(a)))
-//   errs.Append(errors.Caller(fn(b)))
+//   errs.Append(errors.WithCaller(fn(a)))
+//   errs.Append(errors.WithCaller(fn(b)))
 //   err := errs.Err()
 //
 package errors


### PR DESCRIPTION
As a consequence rename the existing Caller etc as WithCaller.