### PR TITLE
cmdutil/structdoc: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 It contains the following submodules, each of which can be imported and
 versioned independently.
 
-- [cmdutil](cmdutil/README.md): provides support for building command line tools.
-- [errors](errors/README.md): provides support for working with go errors post go 1.13.
-- [path](path/README.md): provides support for working with paths and filenames, including cloud storage systems.
-- [sync](sync/README.md): provides easy to use patterns for working with goroutines and concurrency.
-- [text](text/README.md): provides support for operating on text/in-memory data.
+- [cmdutil](cmdutil/README.md): support for building command line tools.
+- [cmdutil/flags](cmdutil/flags/README.md): support for working with command line flags.
+- [cmdutil/structdoc](cmdutil/structdoc/README.md): support for generating documentation using struct tags.
+- [errors](errors/README.md): support for working with go errors post go 1.13.
+- [path](path/README.md): support for working with paths and filenames, including cloud storage systems.
+- [sync](sync/README.md): easy to use patterns for working with goroutines and concurrency.
+- [text](text/README.md): support for operating on text/in-memory data.
 
 # CI notes
 - circecli is used for unit tests.

--- a/cmdutil/structdoc/README.md
+++ b/cmdutil/structdoc/README.md
@@ -1,0 +1,50 @@
+# Package [cloudeng.io/cmdutil/structdoc](https://pkg.go.dev/cloudeng.io/cmdutil/structdoc?tab=doc)
+[![CircleCI](https://circleci.com/gh/cloudengio/go.gotools.svg?style=svg)](https://circleci.com/gh/cloudengio/go.gotools) [![Go Report Card](https://goreportcard.com/badge/cloudeng.io/cmdutil/structdoc)](https://goreportcard.com/report/cloudeng.io/cmdutil/structdoc)
+
+```go
+import cloudeng.io/cmdutil/structdoc
+```
+
+Package structdoc provides a means of exposing struct tags for use when
+generating documentation for those structs.
+
+## Functions
+### Func TypeName
+```go
+func TypeName(t interface{}) string
+```
+TypeName returns the fully qualified name of the supplied type or the string
+representation of an anonymous type.
+
+
+
+## Types
+### Type Description
+```go
+type Description struct {
+	Detail string
+	Fields []Field
+}
+```
+Description represents a structured description of a struct type based on
+struct tags. The Detail field may be supplied when constructing the
+description.
+
+### Type Field
+```go
+type Field struct {
+	// Name is the name of the original field. The name takes
+	// into account any name specified via a json or yaml tag.
+	Name string
+	// Doc is the text extracted from the struct tag for this field.
+	Doc string
+	// Fields, if this field is a struct, contains descriptions for
+	// any documented fields in that struct.
+	Fields []Field `json:",omitempty" yaml:",omitempty"`
+}
+```
+Field represents the description of a field and any similarly tagged
+subfields.
+
+
+

--- a/cmdutil/structdoc/structdoc.go
+++ b/cmdutil/structdoc/structdoc.go
@@ -1,0 +1,119 @@
+// Copyright 2020 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+// Package structdoc provides a means of exposing struct tags for use for
+// generating documentation for those structs.
+package structdoc
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// Field represents the description of a single field.
+type Field struct {
+	// Name is the name of the original field. The name takes into account
+	// any name specified via a json or yaml tag.
+	Name string
+	// Doc is the text extracted from the struct tag for this field.
+	Doc    string
+	Fields []Field `json:",omitempty" yaml:",omitempty"`
+}
+
+func describeTags(tagName string, typ reflect.Type) []Field {
+	var fields []Field
+	for nf := 0; nf < typ.NumField(); nf++ {
+		field := typ.Field(nf)
+		doc, ok := field.Tag.Lookup(tagName)
+		name := field.Name
+		// Heurestic to use the same name as any other intended encoding
+		// for this field.
+		for _, encoding := range []string{"yaml", "json"} {
+			if etag, ok := field.Tag.Lookup(encoding); ok {
+				if parts := strings.Split(etag, ","); len(parts) > 0 {
+					name = parts[0]
+				}
+			}
+		}
+		var subFields []Field
+		if field.Type.Kind() == reflect.Struct {
+			subFields = describeTags(tagName, field.Type)
+		}
+		if !ok && (len(subFields) == 0) {
+			continue
+		}
+		fields = append(fields, Field{Name: name, Doc: doc, Fields: subFields})
+	}
+	return fields
+}
+
+// Description represents a structured description of a struct type based
+// on struct tags. The Detail field may be supplied when constructing
+// the description.
+type Description struct {
+	Detail string
+	Fields []Field
+}
+
+func describeFields(indent int, fields []Field) string {
+	max := 0
+	for _, field := range fields {
+		if l := len(field.Name); l > max {
+			max = l
+		}
+	}
+	out := &strings.Builder{}
+	spaces := strings.Repeat(" ", indent)
+	for _, field := range fields {
+		out.WriteString(spaces)
+		out.WriteString(field.Name)
+		out.WriteString(":")
+		out.WriteString(strings.Repeat(" ", max-len(field.Name)+1))
+		out.WriteString(field.Doc)
+		out.WriteString("\n")
+		if len(field.Fields) > 0 {
+			out.WriteString(describeFields(indent+2, field.Fields))
+		}
+	}
+	return out.String()
+}
+
+// String returns a string representation of the description.
+func (d *Description) String() string {
+	out := &strings.Builder{}
+	out.WriteString(d.Detail)
+	out.WriteString(describeFields(0, d.Fields))
+	return out.String()
+}
+
+// TypeName returns the fully qualified name of the supplied type or
+// the string representation of an anonymous type.
+func TypeName(t interface{}) string {
+	typ := reflect.TypeOf(t)
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	if name := typ.Name(); len(name) > 0 {
+		return typ.PkgPath() + "." + name
+	}
+	return typ.String()
+}
+
+// Describe generates a Description for the supplied type based on its
+// struct tags. Detail can be used to provide a top level of detail,
+// such as the type name and a summary.
+func Describe(t interface{}, tag, detail string) (*Description, error) {
+	typ := reflect.TypeOf(t)
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	if typ.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("%T is not a struct", t)
+	}
+	return &Description{
+		Detail: detail,
+		Fields: describeTags(tag, typ),
+	}, nil
+}

--- a/cmdutil/structdoc/structdoc.go
+++ b/cmdutil/structdoc/structdoc.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the Apache-2.0
 // license that can be found in the LICENSE file.
 
-// Package structdoc provides a means of exposing struct tags for use for
+// Package structdoc provides a means of exposing struct tags for use when
 // generating documentation for those structs.
 package structdoc
 
@@ -12,13 +12,16 @@ import (
 	"strings"
 )
 
-// Field represents the description of a single field.
+// Field represents the description of a field and any similarly tagged
+// subfields.
 type Field struct {
-	// Name is the name of the original field. The name takes into account
-	// any name specified via a json or yaml tag.
+	// Name is the name of the original field. The name takes
+	// into account any name specified via a json or yaml tag.
 	Name string
 	// Doc is the text extracted from the struct tag for this field.
-	Doc    string
+	Doc string
+	// Fields, if this field is a struct, contains descriptions for
+	// any documented fields in that struct.
 	Fields []Field `json:",omitempty" yaml:",omitempty"`
 }
 

--- a/cmdutil/structdoc/structdoc_test.go
+++ b/cmdutil/structdoc/structdoc_test.go
@@ -1,0 +1,58 @@
+package structdoc_test
+
+import (
+	"strings"
+	"testing"
+
+	"cloudeng.io/cmdutil/structdoc"
+)
+
+type S2 struct {
+	B float32 `tag:"bar"`
+}
+type S1 struct {
+	A int `tag:"foo"`
+	B S2  `tag:"foo-bar"`
+}
+
+func TestStructDoc(t *testing.T) {
+	for i, tc := range []struct {
+		in   interface{}
+		doc  string
+		name string
+	}{
+		{struct {
+			A string `tag:"doc"`
+			B string // ignored
+		}{}, "detail:\nA: doc\n",
+			`struct { A string "tag:\"doc\""; B string }`,
+		},
+		{struct {
+			A string `json:"b" tag:"doc"`
+		}{}, "detail:\nb: doc\n",
+			`struct { A string "json:\"b\" tag:\"doc\"" }`,
+		},
+		{struct {
+			A string `yaml:"c" tag:"doc"`
+		}{}, "detail:\nc: doc\n",
+			`struct { A string "yaml:\"c\" tag:\"doc\"" }`,
+		},
+		{&S1{}, "detail:\nA: foo\nB: foo-bar\n  B: bar\n", "cloudeng.io/cmdutil/structdoc_test.S1"},
+	} {
+		desc, err := structdoc.Describe(tc.in, "tag", "detail:\n")
+		if err != nil {
+			t.Errorf("%v: %v", i, err)
+			continue
+		}
+		if got, want := desc.String(), tc.doc; got != want {
+			t.Errorf("%v: got %v, want %v", i, got, want)
+		}
+		if got, want := structdoc.TypeName(tc.in), tc.name; got != want {
+			t.Errorf("%v: got %v, want %v", i, got, want)
+		}
+	}
+	_, err := structdoc.Describe(32, "tag", "detail")
+	if err == nil || !strings.Contains(err.Error(), "int is not a struct") {
+		t.Errorf("unexpected or missing error: %v", err)
+	}
+}


### PR DESCRIPTION
structdoc provides a means of exposing struct tags for use when generating documentation for those structs.