### PR TITLE
cmdutil/flags: add expansion of environment variables

### DIFF
--- a/cmdutil/flags/flagvar.go
+++ b/cmdutil/flags/flagvar.go
@@ -15,6 +15,7 @@ package flags
 import (
 	"flag"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"time"
@@ -102,6 +103,9 @@ func parseField(t, field string, allowEmpty, expectMore bool) (value, remaining 
 // description for the flag.
 // <default-value> may be left empty, but <name> and <usage> must
 // be supplied. All fields can be quoted if they need to contain a comma.
+//
+// Default values may contain shell variables as per os.ExpandEnv.
+// So $HOME/.configdir may be used for example.
 func ParseFlagTag(t string) (name, value, usage string, err error) {
 	if len(t) == 0 {
 		err = fmt.Errorf("empty or missing tag")
@@ -139,7 +143,7 @@ func defaultLiteralValue(typeName string) interface{} {
 	return nil
 }
 
-func literalDefault(typeName, literal string, initialValue interface{}) (value interface{}, err error) {
+func literalDefault(typeName, literal string, initialValue interface{}) (value interface{}, usageDefault string, err error) {
 	if initialValue != nil {
 		switch v := initialValue.(type) {
 		case int, int64, uint, uint64, bool, float64, string, time.Duration:
@@ -148,7 +152,12 @@ func literalDefault(typeName, literal string, initialValue interface{}) (value i
 		}
 	}
 	if len(literal) == 0 {
-		return defaultLiteralValue(typeName), nil
+		value = defaultLiteralValue(typeName)
+		return
+	}
+	if tmp := os.ExpandEnv(literal); tmp != literal {
+		usageDefault = literal
+		literal = tmp
 	}
 	var tmp int64
 	var utmp uint64
@@ -221,7 +230,6 @@ func RegisterFlagsInStruct(fs *flag.FlagSet, tag string, structWithFlags interfa
 		}
 		fs.Lookup(k).DefValue = v
 	}
-
 	return nil
 }
 
@@ -334,7 +342,7 @@ func registerFlagsInStruct(fs *flag.FlagSet, tag string, structWithFlags interfa
 			return fmt.Errorf("%v: field can't be a pointer", errPrefix())
 		}
 
-		initialValue, err := literalDefault(fieldTypeName, value, valueDefaults[name])
+		initialValue, usageDefault, err := literalDefault(fieldTypeName, value, valueDefaults[name])
 		if err != nil {
 			return fmt.Errorf("%v: failed to set initial default value: %v", errPrefix(), err)
 		}
@@ -348,6 +356,9 @@ func registerFlagsInStruct(fs *flag.FlagSet, tag string, structWithFlags interfa
 		if !createFlagsBasedOnValue(fs, initialValue, fieldValue, name, description) {
 			// should never reach here.
 			panic(fmt.Sprintf("%v flag: field %v, flag %v: unsupported type %T", fieldTypeName, fieldName, name, initialValue))
+		}
+		if len(usageDefault) > 0 {
+			fs.Lookup(name).DefValue = usageDefault
 		}
 	}
 	return nil

--- a/cmdutil/flags/flagvar_test.go
+++ b/cmdutil/flags/flagvar_test.go
@@ -7,6 +7,7 @@ package flags_test
 import (
 	"flag"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -24,6 +25,7 @@ func ExampleRegisterFlagsInStruct() {
 		A int    `flag:"int-flag,-1,intVar flag"`
 		B string `flag:"string-flag,'some,value,with,a,comma',stringVar flag"`
 		O int
+		H string `flag:"config,$HOME/config,config file in home directotyr"`
 	}{
 		O: 23,
 	}
@@ -37,6 +39,9 @@ func ExampleRegisterFlagsInStruct() {
 	flagSet.Parse([]string{"--int-flag=42"})
 	fmt.Println(eg.A)
 	fmt.Println(eg.B)
+	if got, want := eg.H, filepath.Join(os.Getenv("HOME"), "config"); got != want {
+		fmt.Printf("got %v, want %v", got, want)
+	}
 	// Output:
 	// -1
 	// some,value,with,a,comma
@@ -289,6 +294,42 @@ func TestRegister(t *testing.T) {
 	assert(s1.HNQ, "42")
 	assert(s1.V, myFlagVar(42))
 	assert(s1.X, myFlagVar(12))
+
+	os.Setenv("ENV_INT_TESTING", "0")
+	// Test shell variable expansion and functions.
+	s2 := struct {
+		A string `cmdline:"configA,$HOME/.config,config flag"`
+		B string `cmdline:"configB,$HOME/.config,config flag"`
+		C string `cmdline:"configC,$HOME/.config,config flag"`
+		D int    `cmdline:"exitCode,$ENV_INT_TESTING,an integer environment variable"`
+	}{}
+	values = map[string]interface{}{
+		"configB": "something-else",
+	}
+	usageDefaults = map[string]string{
+		"configC": "override",
+	}
+
+	expectedUsage = []string{
+		`cmdline:"configA,$HOME/.config,config flag"`,
+		`cmdline:"configB,something-else,config flag"`,
+		`cmdline:"configC,override,config flag"`,
+		`cmdline:"exitCode,$ENV_INT_TESTING,an integer environment variable"`,
+	}
+	sort.Strings(expectedUsage)
+
+	fs = &flag.FlagSet{}
+	err = flags.RegisterFlagsInStruct(fs, "cmdline", &s2, values, usageDefaults)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if got, want := allFlags(fs), strings.Join(expectedUsage, "\n"); got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	assert(strings.Contains(s2.A, "$HOME"), false)
+	assert(s2.B, "something-else")
+	assert(strings.Contains(s2.C, "$HOME"), false)
+	assert(s2.D >= 0, true)
 
 }
 


### PR DESCRIPTION
Add back the ability to expand environment variables in default values for flags (e.g. $HOME/.config) which somehow got lost in the transition from v.io/x/lib.