### PR TITLE
sync/ctxsync: add context aware sync primitives

### DIFF
--- a/cmdutil/flags/README.md
+++ b/cmdutil/flags/README.md
@@ -59,6 +59,9 @@ default value for the flag and <usage> the detailed description for the
 flag. <default-value> may be left empty, but <name> and <usage> must be
 supplied. All fields can be quoted if they need to contain a comma.
 
+Default values may contain shell variables as per os.ExpandEnv. So
+$HOME/.configdir may be used for example.
+
 ### Func RegisterFlagsInStruct
 ```go
 func RegisterFlagsInStruct(fs *flag.FlagSet, tag string, structWithFlags interface{}, valueDefaults map[string]interface{}, usageDefaults map[string]string) error

--- a/sync/ctxsync/README.md
+++ b/sync/ctxsync/README.md
@@ -29,4 +29,9 @@ whichever comes first.
 
 
 
+## Examples
+### [ExampleWaitGroup](https://pkg.go.dev/cloudeng.io/sync/ctxsync?tab=doc#example-WaitGroup)
+
+
+
 

--- a/sync/ctxsync/README.md
+++ b/sync/ctxsync/README.md
@@ -1,0 +1,32 @@
+# Package [cloudeng.io/sync/ctxsync](https://pkg.go.dev/cloudeng.io/sync/ctxsync?tab=doc)
+[![CircleCI](https://circleci.com/gh/cloudengio/go.gotools.svg?style=svg)](https://circleci.com/gh/cloudengio/go.gotools) [![Go Report Card](https://goreportcard.com/badge/cloudeng.io/sync/ctxsync)](https://goreportcard.com/report/cloudeng.io/sync/ctxsync)
+
+```go
+import cloudeng.io/sync/ctxsync
+```
+
+Package ctxsync provides context aware synchronisation primitives.
+
+## Types
+### Type WaitGroup
+```go
+type WaitGroup struct {
+	sync.WaitGroup
+}
+```
+WaitGroup represents a context aware sync.WaitGroup
+
+### Methods
+
+```go
+func (wg *WaitGroup) Wait(ctx context.Context)
+```
+Wait blocks until the WaitGroup reaches zero or the context is canceled,
+whichever comes first.
+
+
+
+
+
+
+

--- a/sync/ctxsync/wg.go
+++ b/sync/ctxsync/wg.go
@@ -1,0 +1,30 @@
+// Copyright 2020 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+// Package ctxsync provides context aware synchronisation primitives.
+package ctxsync
+
+import (
+	"context"
+	"sync"
+)
+
+// WaitGroup represents a context aware sync.WaitGroup
+type WaitGroup struct {
+	sync.WaitGroup
+}
+
+// Wait blocks until the WaitGroup reaches zero or the
+// context is canceled, whichever comes first.
+func (wg *WaitGroup) Wait(ctx context.Context) {
+	ch := make(chan struct{})
+	go func() {
+		wg.WaitGroup.Wait()
+		close(ch)
+	}()
+	select {
+	case <-ch:
+	case <-ctx.Done():
+	}
+}

--- a/sync/ctxsync/wg_test.go
+++ b/sync/ctxsync/wg_test.go
@@ -1,0 +1,58 @@
+// Copyright 2020 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+package ctxsync_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"cloudeng.io/sync/ctxsync"
+)
+
+func ExampleWaitGrouo() {
+	var wg ctxsync.WaitGroup
+	wg.Add(1)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(time.Second)
+		cancel()
+	}()
+	wg.Wait(ctx)
+	fmt.Println(ctx.Err())
+	// Output:
+	// context canceled
+}
+
+func TestWaitGroupInline(t *testing.T) {
+	var wg ctxsync.WaitGroup
+	wg.Add(1)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	wg.Wait(ctx)
+	if got, want := ctx.Err().Error(), "context canceled"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestWaitGroup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg ctxsync.WaitGroup
+	wg.Add(1)
+	var out string
+	go func() {
+		out = "done"
+		wg.Done()
+	}()
+	wg.Wait(ctx)
+	if got, want := out, "done"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	cancel()
+	wg.Add(1)
+	wg.Wait(ctx)
+	// The test will timeout if we never get here.
+}

--- a/sync/ctxsync/wg_test.go
+++ b/sync/ctxsync/wg_test.go
@@ -13,7 +13,7 @@ import (
 	"cloudeng.io/sync/ctxsync"
 )
 
-func ExampleWaitGrouo() {
+func ExampleWaitGroup() {
 	var wg ctxsync.WaitGroup
 	wg.Add(1)
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
This PR adds a package for context aware sync primitives. The initial member is a simple wrapping of
sync.WaitGroup where the Wait can be terminated via context cancelation.