### PR TITLE
cmdutil/signals: revised API

### DIFF
--- a/cmdutil/expect/README.md
+++ b/cmdutil/expect/README.md
@@ -25,7 +25,7 @@ different input orderings.
 ### Functions
 
 ```go
-func NewLineStream(rd io.Reader) *Lines
+func NewLineStream(rd io.Reader, opts ...Option) *Lines
 ```
 NewLineStream creates a new instance of Lines.
 
@@ -87,6 +87,22 @@ func (s *Lines) LastMatch() (int, string)
 ```
 LastMatch returns the line number and contents of the last successfully
 matched input line.
+
+
+
+
+### Type Option
+```go
+type Option func(*options)
+```
+Option represents an option.
+
+### Functions
+
+```go
+func TraceInput(out io.Writer) Option
+```
+TraceInput enables tracing of input as it is read.
 
 
 

--- a/cmdutil/signals/README.md
+++ b/cmdutil/signals/README.md
@@ -69,6 +69,10 @@ type Handler struct {
 	// contains filtered or unexported fields
 }
 ```
+Handler represents a signal handler that can be used to wait for signal
+reception or context cancelation as per NotifyWithCancel. In addition it can
+be used to register additional cancel functions to be invoked on signal
+reception or context cancelation.
 
 ### Functions
 
@@ -102,11 +106,15 @@ after that will similarly lead to os.Exit(ExitCode) being called.
 ```go
 func (h *Handler) RegisterCancel(fns ...func())
 ```
+RegisterCancel registers one or more cancel functions to be invoked when a
+signal is received or the original context is canceled.
 
 
 ```go
 func (h *Handler) WaitForSignal() os.Signal
 ```
+WaitForSignal will wait for a signal to be received. Context cancelation is
+translated into a ContextDoneSignal signal.
 
 
 

--- a/cmdutil/signals/README.md
+++ b/cmdutil/signals/README.md
@@ -37,28 +37,6 @@ func Defaults() []os.Signal
 ```
 Defaults returns a set of platform specific signals that are commonly used.
 
-### Func NotifyWithCancel
-```go
-func NotifyWithCancel(ctx context.Context, signals ...os.Signal) (context.Context, func() os.Signal)
-```
-NotifyWithCancel is like signal.Notify except that it forks (and returns)
-the supplied context to obtain a cancel function that is called when a
-signal is received. It will also catch the cancelation of the supplied
-context and turn into an instance of ContextDoneSignal. The returned
-function can be used to wait for the signals to be received, a function is
-returned to allow for the convenient use of defer. Typical usage would be:
-
-func main() {
-
-      ctx, wait := signals.NotifyWithCancel(context.Background(), signals.Defaults()...)
-      ....
-      defer wait() // wait for a signal or context cancelation.
-    }
-
-If a second, different, signal is received then os.Exit(ExitCode) is called.
-Subsequent signals are the same as the first are ignored for one second but
-after that will similarly lead to os.Exit(ExitCode) being called.
-
 
 
 ## Types
@@ -81,6 +59,54 @@ Signal implements os.Signal.
 func (s ContextDoneSignal) String() string
 ```
 Stringimplements os.Signal.
+
+
+
+
+### Type Handler
+```go
+type Handler struct {
+	// contains filtered or unexported fields
+}
+```
+
+### Functions
+
+```go
+func NotifyWithCancel(ctx context.Context, signals ...os.Signal) (context.Context, *Handler)
+```
+NotifyWithCancel is like signal.Notify except that it forks (and returns)
+the supplied context to obtain a cancel function that is called when a
+signal is received. It will also catch the cancelation of the supplied
+context and turn it into an instance of ContextDoneSignal. The returned
+handler can be used to wait for the signals to be received and to register
+additional cancelation functions to be invoked when a signal is received.
+Typical usage would be:
+
+    func main() {
+       ctx, handler := signals.NotifyWithCancel(context.Background(), signals.Defaults()...)
+       ....
+       handler.RegisterCancel(func() { ... })
+       ...
+       defer hanlder.WaitForSignal() // wait for a signal or context cancelation.
+     }
+
+If a second, different, signal is received then os.Exit(ExitCode) is called.
+Subsequent signals are the same as the first are ignored for one second but
+after that will similarly lead to os.Exit(ExitCode) being called.
+
+
+
+### Methods
+
+```go
+func (h *Handler) RegisterCancel(fns ...func())
+```
+
+
+```go
+func (h *Handler) WaitForSignal() os.Signal
+```
 
 
 

--- a/cmdutil/signals/signals.go
+++ b/cmdutil/signals/signals.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -29,23 +30,50 @@ const (
 // signals are ignored.
 var DebounceDuration time.Duration = time.Second
 
+type Handler struct {
+	mu         sync.Mutex
+	retCh      chan os.Signal
+	cancelList []func()
+}
+
+func (h *Handler) RegisterCancel(fns ...func()) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.cancelList = append(h.cancelList, fns...)
+}
+
+func (h *Handler) cancel() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, cancel := range h.cancelList {
+		cancel()
+	}
+}
+
+func (h *Handler) WaitForSignal() os.Signal {
+	return <-h.retCh
+}
+
 // NotifyWithCancel is like signal.Notify except that it forks (and returns) the
 // supplied context to obtain a cancel function that is called when a signal
 // is received. It will also catch the cancelation of the supplied context
-// and turn into an instance of ContextDoneSignal. The returned function can
-// be used to wait for the signals to be received, a function is returned to
-// allow for the convenient use of defer. Typical usage would be:
+// and turn it into an instance of ContextDoneSignal. The returned handler can
+// be used to wait for the signals to be received and to register additional
+// cancelation functions to be invoked when a signal is received. Typical usage
+// would be:
 //
-// func main() {
-//    ctx, wait := signals.NotifyWithCancel(context.Background(), signals.Defaults()...)
-//    ....
-//    defer wait() // wait for a signal or context cancelation.
-//  }
+//   func main() {
+//      ctx, handler := signals.NotifyWithCancel(context.Background(), signals.Defaults()...)
+//      ....
+//      handler.RegisterCancel(func() { ... })
+//      ...
+//      defer hanlder.WaitForSignal() // wait for a signal or context cancelation.
+//    }
 //
 // If a second, different, signal is received then os.Exit(ExitCode) is called.
 // Subsequent signals are the same as the first are ignored for one second
 // but after that will similarly lead to os.Exit(ExitCode) being called.
-func NotifyWithCancel(ctx context.Context, signals ...os.Signal) (context.Context, func() os.Signal) {
+func NotifyWithCancel(ctx context.Context, signals ...os.Signal) (context.Context, *Handler) {
 	ctx, cancel := context.WithCancel(ctx)
 
 	// Never drop the first two signals.
@@ -55,6 +83,7 @@ func NotifyWithCancel(ctx context.Context, signals ...os.Signal) (context.Contex
 
 	// Never block on forwarding the first signal.
 	retCh := make(chan os.Signal, 1)
+	handler := &Handler{retCh: retCh}
 	go func() {
 		close(isRunning)
 		var sig os.Signal
@@ -64,8 +93,10 @@ func NotifyWithCancel(ctx context.Context, signals ...os.Signal) (context.Contex
 			sigTime = time.Now()
 			retCh <- sig
 			cancel()
+			handler.cancel()
 		case <-ctx.Done():
 			retCh <- ContextDoneSignal(ctx.Err().Error())
+			handler.cancel()
 			return
 		}
 		for {
@@ -76,9 +107,7 @@ func NotifyWithCancel(ctx context.Context, signals ...os.Signal) (context.Contex
 		}
 	}()
 	<-isRunning
-	return ctx, func() os.Signal {
-		return <-retCh
-	}
+	return ctx, handler
 }
 
 // ContextDoneSignal implements os.Signal and is used to translate a

--- a/cmdutil/signals/signals_test.go
+++ b/cmdutil/signals/signals_test.go
@@ -68,6 +68,11 @@ func TestSignal(t *testing.T) {
 		syscall.Kill(pid, syscall.SIGINT)
 		wg.Done()
 	}()
+
+	if err := st.ExpectEventuallyRE(ctx, regexp.MustCompile(`CANCEL PID=\d+`)); err != nil {
+		t.Fatal(err)
+	}
+
 	if err := st.ExpectNext(ctx, "interrupt"); err != nil {
 		t.Fatal(err)
 	}
@@ -85,6 +90,9 @@ func TestSignal(t *testing.T) {
 		time.Sleep(time.Millisecond * 250)
 		syscall.Kill(pid, syscall.SIGINT)
 	}()
+	if err := st.ExpectEventuallyRE(ctx, regexp.MustCompile(`CANCEL PID=\d+`)); err != nil {
+		t.Fatal(err)
+	}
 	if err := st.ExpectNext(ctx, "exit status 1"); err != nil {
 		t.Fatal(err)
 	}
@@ -97,14 +105,41 @@ func TestSignal(t *testing.T) {
 
 func TestCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	_, wait := signals.NotifyWithCancel(ctx, os.Interrupt)
+	_, handler := signals.NotifyWithCancel(ctx, os.Interrupt)
 
 	go func() {
 		cancel()
 	}()
 
-	sig := wait()
+	sig := handler.WaitForSignal()
 	if got, want := sig.String(), "context canceled"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestMultipleCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	_, handler := signals.NotifyWithCancel(ctx, os.Interrupt)
+	out := []string{}
+	handler.RegisterCancel(
+		func() {
+			out = append(out, "a")
+		},
+		func() {
+			out = append(out, "b")
+		},
+	)
+
+	go func() {
+		cancel()
+	}()
+
+	sig := handler.WaitForSignal()
+	if got, want := sig.String(), "context canceled"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	time.Sleep(time.Second)
+	if got, want := strings.Join(out, ""), "ab"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 }

--- a/cmdutil/signals/testdata/signal_main.go
+++ b/cmdutil/signals/testdata/signal_main.go
@@ -26,9 +26,12 @@ func main() {
 	flag.Parse()
 	signals.DebounceDuration = time.Millisecond * 250
 	ctx := context.Background()
-	ctx, wait := signals.NotifyWithCancel(ctx, os.Interrupt)
+	ctx, handler := signals.NotifyWithCancel(ctx, os.Interrupt)
+	handler.RegisterCancel(func() {
+		fmt.Printf("CANCEL PID=%v\n", os.Getpid())
+	})
 	fmt.Printf("PID=%v\n", os.Getpid())
-	sig := wait()
+	sig := handler.WaitForSignal()
 	time.Sleep(signals.DebounceDuration * 2)
 	fmt.Println(sig.String())
 }


### PR DESCRIPTION
Revise the signals API to allow for registering additional cancel functions to be called when a signal is received or the context canceled. It also seems more obvious to call handler.WaitForSignals() rather than 'functionName()' to wait for signals.