### PR TITLE
cmdutil,os,algo,file: minor changes to these packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
       - run:
           name: test
           command: |
+            export USER=circleci
             for dir in $(find * -maxdepth 0 -type d); do
               pushd "${dir}"
               go get -t -d ./...

--- a/README.md
+++ b/README.md
@@ -3,19 +3,14 @@
 # go.pkgs contains a set of broadly useful go packages.
 
 It contains the following submodules, each of which can be imported and
-versioned independently.
+versioned independently. 
 
 - [algo](algo/README.md): common algorithm implementations.
 - [cmdutil](cmdutil/README.md): support for building command line tools.
-- [cmdutil/flags](cmdutil/flags/README.md): support for working with command line flags.
-- [cmdutil/profiling](cmdutil/profiling/README.md): support for requesting profiles from the command line.
-- [cmdutil/structdoc](cmdutil/structdoc/README.md): support for generating documentation using struct tags.
-- [debug/instrument] (debug/instrument/README.md): support for instrumenting code to
-trace execution and communication.
+- [debug](debug/README.md): support for instrumenting code to trace execution and communication.
 - [errors](errors/README.md): support for working with go errors post go 1.13.
 - [file](file/README.md): support for working with files and filesystems, including cloud storage systems.
 - [os](os/README.md): os related and/or specific packages.
 - [path](path/README.md): support for working with paths and filenames, including cloud storage systems.
 - [sync](sync/README.md): easy to use patterns for working with goroutines and concurrency.
 - [text](text/README.md): support for operating on text/in-memory data.
-- [text/linewrap](text/linewrap/README.md): simple line wrapping.

--- a/algo/container/heap/README.md
+++ b/algo/container/heap/README.md
@@ -22,7 +22,7 @@ desencding operations and is safe for concurrent use.
 ### Functions
 
 ```go
-func NewKeyedInt64(descending bool) *KeyedInt64
+func NewKeyedInt64(order Order) *KeyedInt64
 ```
 NewKeyedInt64 returns a new instance of KeyedInt64.
 
@@ -74,8 +74,8 @@ Sum returns the current sum of all values in the heap.
 
 ```go
 func (ki *KeyedInt64) TopN(n int) []struct {
-	Key   string
-	Value int64
+	K string
+	V int64
 }
 ```
 TopN removes at most the top most n items from the heap.
@@ -91,6 +91,23 @@ UnmarshalJSON implements json.Unmarshaler.
 func (ki *KeyedInt64) Update(key string, value int64)
 ```
 Update updates the value associated with key or it adds it to the heap.
+
+
+
+
+### Type Order
+```go
+type Order bool
+```
+Order determines if the heap is maintained in ascending or descending order.
+
+### Constants
+### Ascending, Descending
+```go
+Ascending Order = false
+Descending Order = true
+
+```
 
 
 

--- a/cmdutil/subcmd/subcmd.go
+++ b/cmdutil/subcmd/subcmd.go
@@ -456,7 +456,10 @@ func (cmds *CommandSet) DispatchWithArgs(ctx context.Context, usage string, args
 		fs := cmds.global.flagSet
 		if err := fs.Parse(args); err != nil {
 			if err == flag.ErrHelp {
-				fmt.Fprintln(cmds.out, cmds.Usage(usage), cmds.globalDefaults())
+				fmt.Fprintln(cmds.out, cmds.Usage(usage))
+				if gd := cmds.globalDefaults(); len(gd) > 0 {
+					fmt.Fprintf(cmds.out, "%s", gd)
+				}
 			}
 			return err
 		}

--- a/file/filewalk/localdb/localdb.go
+++ b/file/filewalk/localdb/localdb.go
@@ -226,9 +226,7 @@ func Open(ctx context.Context, dir string, ifcOpts []filewalk.DatabaseOption, op
 		fn(db)
 	}
 
-	err := db.acquireLock(ctx, db.opts.readOnly, db.opts.lockRetryDelay, db.opts.tryLock)
-
-	if err != nil {
+	if err := db.acquireLock(ctx, db.opts.readOnly, db.opts.lockRetryDelay, db.opts.tryLock); err != nil {
 		return nil, err
 	}
 
@@ -242,6 +240,7 @@ func Open(ctx context.Context, dir string, ifcOpts []filewalk.DatabaseOption, op
 		cfg.SyncInterval = 0
 	}
 
+	var err error
 	db.prefixdb, err = pudge.Open(filepath.Join(dir, prefixdbFilename), &cfg)
 	if err != nil {
 		return nil, err

--- a/os/userid/README.md
+++ b/os/userid/README.md
@@ -26,6 +26,7 @@ IDInfo represents the parsed output of the 'id' command.
 ```go
 func ParseIDCommandOutput(out string) (IDInfo, error)
 ```
+ParseIDCommandOutput parses the output of the unix id command.
 
 
 
@@ -55,7 +56,7 @@ func (idm *IDManager) Lookup(id string) (IDInfo, error)
 ```
 LookupID returns IDInfo for the specified user id or user name. It returns
 user.UnknownUserError if the user cannot be found or the invocation of the
-id command fails somehow.
+'id' command fails somehow.
 
 
 

--- a/os/userid/README.md
+++ b/os/userid/README.md
@@ -1,0 +1,65 @@
+# Package [cloudeng.io/os/userid](https://pkg.go.dev/cloudeng.io/os/userid?tab=doc)
+[![CircleCI](https://circleci.com/gh/cloudengio/go.gotools.svg?style=svg)](https://circleci.com/gh/cloudengio/go.gotools) [![Go Report Card](https://goreportcard.com/badge/cloudeng.io/os/userid)](https://goreportcard.com/report/cloudeng.io/os/userid)
+
+```go
+import cloudeng.io/os/userid
+```
+
+Package userid provides analogous functionality to the standard os/user
+package except that it uses the 'id' command to obtain user and group
+information rather than /etc/passwd since on many system installations the
+user package will fail to find a user whereas the id command can.
+
+## Types
+### Type IDInfo
+```go
+type IDInfo struct {
+	UID, Username  string
+	GID, Groupname string
+	Groups         []user.Group
+}
+```
+IDInfo represents the parsed output of the 'id' command.
+
+### Functions
+
+```go
+func ParseIDCommandOutput(out string) (IDInfo, error)
+```
+
+
+
+
+### Type IDManager
+```go
+type IDManager struct {
+	// contains filtered or unexported fields
+}
+```
+IDManager implements a caching lookup of user information by id or username
+that uses the 'id' command.
+
+### Functions
+
+```go
+func NewIDManager() *IDManager
+```
+NewIDManager creates a new instance of IDManager.
+
+
+
+### Methods
+
+```go
+func (idm *IDManager) Lookup(id string) (IDInfo, error)
+```
+LookupID returns IDInfo for the specified user id or user name. It returns
+user.UnknownUserError if the user cannot be found or the invocation of the
+id command fails somehow.
+
+
+
+
+
+
+

--- a/os/userid/idmanager_test.go
+++ b/os/userid/idmanager_test.go
@@ -26,4 +26,8 @@ func TestManager(t *testing.T) {
 	if got, want := ok, true; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
+	id, ok = idm.exists(id.UID)
+	if got, want := id.Username, user; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
 }

--- a/os/userid/idmanager_test.go
+++ b/os/userid/idmanager_test.go
@@ -1,0 +1,29 @@
+// Copyright 2020 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+package userid
+
+import (
+	"os"
+	"testing"
+)
+
+func TestManager(t *testing.T) {
+	idm := NewIDManager()
+	user := os.Getenv("USER")
+	id, err := idm.Lookup(user)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := id.Username, user; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	id, ok := idm.exists(user)
+	if got, want := id.Username, user; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := ok, true; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/os/userid/idmanager_test.go
+++ b/os/userid/idmanager_test.go
@@ -27,6 +27,9 @@ func TestManager(t *testing.T) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 	id, ok = idm.exists(id.UID)
+	if got, want := ok, true; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
 	if got, want := id.Username, user; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}

--- a/os/userid/user.go
+++ b/os/userid/user.go
@@ -1,0 +1,124 @@
+// Copyright 2020 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+// Package userid provides analogous functionality to the standard os/user
+// package except that it uses the 'id' command to obtain user and group
+// information rather than /etc/passwd since on many system installations
+// the user package will fail to find a user whereas the id command can.
+package userid
+
+import (
+	"fmt"
+	"os/exec"
+	"os/user"
+	"strings"
+	"sync"
+)
+
+// IDInfo represents the parsed output of the 'id' command.
+type IDInfo struct {
+	UID, Username  string
+	GID, Groupname string
+	Groups         []user.Group
+}
+
+// parse a(b) and return a, b
+func parseItem(item string) (id, name string) {
+	idxA := strings.Index(item, "(")
+	idxB := strings.Index(item, ")")
+	if idxA < 0 || idxB < 0 || idxA >= idxB {
+		return
+	}
+	return item[:idxA], item[idxA+1 : idxB]
+}
+
+// parse x=y and return x, y
+func parseEquals(field string) (x, y string) {
+	parts := strings.Split(field, "=")
+	if len(parts) != 2 {
+		return
+	}
+	return parts[0], parts[1]
+}
+
+func ParseIDCommandOutput(out string) (IDInfo, error) {
+	var id IDInfo
+	parts := strings.Split(out, " ")
+	if got, want := len(parts), 3; got != want {
+		return id, fmt.Errorf("wrong # of space separated fields, got %v, not %v", got, want)
+	}
+	x, y := parseEquals(parts[0])
+	if x == "uid" {
+		id.UID, id.Username = parseItem(y)
+	} else {
+		return id, fmt.Errorf("first field is not the uid field: %v", x)
+	}
+	x, y = parseEquals(parts[1])
+	if x == "gid" {
+		id.GID, id.Groupname = parseItem(y)
+	} else {
+		return id, fmt.Errorf("second field is not the gid field: %v", x)
+	}
+	x, y = parseEquals(parts[2])
+	if x == "groups" {
+		for _, grp := range strings.Split(y, ",") {
+			gid, name := parseItem(grp)
+			id.Groups = append(id.Groups, user.Group{Gid: gid, Name: name})
+		}
+	} else {
+		return id, fmt.Errorf("third field is not the groups field: %v", x)
+	}
+	return id, nil
+}
+
+// IDManager implements a caching lookup of user information by
+// id or username that uses the 'id' command.
+type IDManager struct {
+	mu    sync.Mutex
+	users map[string]IDInfo
+}
+
+// NewIDManager creates a new instance of IDManager.
+func NewIDManager() *IDManager {
+	return &IDManager{
+		users: map[string]IDInfo{},
+	}
+}
+
+func (idm *IDManager) exists(id string) (IDInfo, bool) {
+	idm.mu.Lock()
+	defer idm.mu.Unlock()
+	info, ok := idm.users[id]
+	return info, ok
+}
+
+// LookupID returns IDInfo for the specified user id or user name.
+// It returns user.UnknownUserError if the user cannot be found or
+// the invocation of the id command fails somehow.
+func (idm *IDManager) Lookup(id string) (IDInfo, error) {
+	if id, exists := idm.exists(id); exists {
+		return id, nil
+	}
+	out, err := runIDCommand(id)
+	if err != nil {
+		return IDInfo{}, user.UnknownUserError(id)
+	}
+	info, err := ParseIDCommandOutput(out)
+	if err != nil {
+		return IDInfo{}, user.UnknownUserError(id)
+	}
+	idm.mu.Lock()
+	defer idm.mu.Unlock()
+	idm.users[id] = info
+	return info, nil
+}
+
+func runIDCommand(uid string) (string, error) {
+	cmd := exec.Command("id", uid)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("%v: %v", strings.Join(cmd.Args, " "), err)
+	}
+	return string(out), err
+}

--- a/os/userid/user.go
+++ b/os/userid/user.go
@@ -2,10 +2,16 @@
 // Use of this source code is governed by the Apache-2.0
 // license that can be found in the LICENSE file.
 
-// Package userid provides analogous functionality to the standard os/user
-// package except that it uses the 'id' command to obtain user and group
-// information rather than /etc/passwd since on many system installations
-// the user package will fail to find a user whereas the id command can.
+// Package userid provides complimentary functionality to the standard os/user
+// package by using the 'id' command to avoid loss of functionality when
+// cross compiling. By way of background os/user has both a pure-go
+// implementation and a cgo implementation. The former parses /etc/passwd
+// and the latter uses the getwpent operations. The cgo implementation
+// cannot be used when cross compiling since cgo is generally disabled for
+// cross compilation. Hence applications that use os/user can find themselves
+// losing the ability to resolve info for all users when cross compiled and used
+// on systems that use a directory service that is accessible via getpwent
+// but whose members do not appear in the text file /etc/passwd.
 package userid
 
 import (

--- a/os/userid/user.go
+++ b/os/userid/user.go
@@ -42,6 +42,7 @@ func parseEquals(field string) (x, y string) {
 	return parts[0], parts[1]
 }
 
+// ParseIDCommandOutput parses the output of the unix id command.
 func ParseIDCommandOutput(out string) (IDInfo, error) {
 	var id IDInfo
 	parts := strings.Split(out, " ")
@@ -95,7 +96,7 @@ func (idm *IDManager) exists(id string) (IDInfo, bool) {
 
 // LookupID returns IDInfo for the specified user id or user name.
 // It returns user.UnknownUserError if the user cannot be found or
-// the invocation of the id command fails somehow.
+// the invocation of the 'id' command fails somehow.
 func (idm *IDManager) Lookup(id string) (IDInfo, error) {
 	if id, exists := idm.exists(id); exists {
 		return id, nil

--- a/os/userid/user.go
+++ b/os/userid/user.go
@@ -111,7 +111,9 @@ func (idm *IDManager) Lookup(id string) (IDInfo, error) {
 	}
 	idm.mu.Lock()
 	defer idm.mu.Unlock()
-	idm.users[id] = info
+	// Save the same information for both user name and user id.
+	idm.users[info.Username] = info
+	idm.users[info.UID] = info
 	return info, nil
 }
 

--- a/os/userid/user_test.go
+++ b/os/userid/user_test.go
@@ -1,0 +1,41 @@
+// Copyright 2020 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+package userid_test
+
+import (
+	"os/user"
+	"reflect"
+	"testing"
+
+	"cloudeng.io/os/userid"
+)
+
+func TestParse(t *testing.T) {
+	ida := userid.IDInfo{
+		UID:       "384864",
+		Username:  "user",
+		GID:       "8577",
+		Groupname: "group",
+		Groups: []user.Group{
+			{"1", "g1"},
+		},
+	}
+	id, err := userid.ParseIDCommandOutput("uid=384864(user) gid=8577(group) groups=1(g1)")
+	if got, want := id, ida; !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	ida.Groups = []user.Group{
+		{"1", "g1"},
+		{"22", "g2"},
+		{"3791", "g3"},
+	}
+	id, err = userid.ParseIDCommandOutput("uid=384864(user) gid=8577(group) groups=1(g1),22(g2),3791(g3)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := id, ida; !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/os/userid/user_test.go
+++ b/os/userid/user_test.go
@@ -19,17 +19,20 @@ func TestParse(t *testing.T) {
 		GID:       "8577",
 		Groupname: "group",
 		Groups: []user.Group{
-			{"1", "g1"},
+			{Gid: "1", Name: "g1"},
 		},
 	}
 	id, err := userid.ParseIDCommandOutput("uid=384864(user) gid=8577(group) groups=1(g1)")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if got, want := id, ida; !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 	ida.Groups = []user.Group{
-		{"1", "g1"},
-		{"22", "g2"},
-		{"3791", "g3"},
+		{Gid: "1", Name: "g1"},
+		{Gid: "22", Name: "g2"},
+		{Gid: "3791", Name: "g3"},
 	}
 	id, err = userid.ParseIDCommandOutput("uid=384864(user) gid=8577(group) groups=1(g1),22(g2),3791(g3)")
 	if err != nil {


### PR DESCRIPTION
Minor changes, apart from the addition of os/userid which can be used to obtain information about the current user via the `id` command which works on a broader range of systems than the standard os/user package (which relies on /etc/passwd when cross compiled).