### PR TITLE
cmdutil/subcmd: allow command tree to be specified in yaml.

### DIFF
--- a/cmdutil/go.mod
+++ b/cmdutil/go.mod
@@ -5,4 +5,5 @@ go 1.16
 require (
 	cloudeng.io/errors v0.0.7
 	cloudeng.io/text v0.0.9
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/cmdutil/go.sum
+++ b/cmdutil/go.sum
@@ -2,3 +2,7 @@ cloudeng.io/errors v0.0.7 h1:GqFEwQrkOhoaF3Nla8tDzHhFwzYYHWmRmGkf4Ag2zGM=
 cloudeng.io/errors v0.0.7/go.mod h1:xWamLL6tn3roKI6MRRFkw1jUkJL9s7CJzFYfaxuhHZk=
 cloudeng.io/text v0.0.9 h1:/2W1L7IsOYbeyHpACriekh0NXCSuFdx+I/eTIml26lI=
 cloudeng.io/text v0.0.9/go.mod h1:nGTZ1g2Wq0fhlGWX5BKPAsChSYeB/MHu1dLI1Kk9004=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cmdutil/subcmd/subcmd.go
+++ b/cmdutil/subcmd/subcmd.go
@@ -63,15 +63,17 @@
 // and the latter for acting on those flags and/or implementing common
 // functionality such as profiling or initializing logging etc.
 //
-// Creating command trees with their documentation is cumbersome using the
-// NewCommand and NewCommandset functions. An easier, and more readable way
-// to do so is via a YAML configuration. The FromYAML function reads a yaml
-// specification of a command tree, its summary documentation and argument
-// specification. The returned CommandSetYAML type can then be used to
-// 'decorate' the command tree with the runner functions and flag value
-// instances. This is more comprehensible means of defining the command
-// tree than doing so entirely via function calls. The YAML mechanism
-// provides identical functionality to calling the functions directly.
+// The FromYAML function provides a more convenient and readable means of creating
+// a command tree than using the NewCommand and NewCommandSet functions directly.
+// FromYAML reads a yaml specification of a command tree, its
+// summary documentation and argument specification and calls NewCommand
+// and NewCommandSet internally.
+//
+// The returned CommandSetYAML type can then be used to 'decorate' the command
+// tree with the runner functions and flag value instances. This is more comprehensible
+// means of defining the command tree than doing so entirely via function calls.
+// The YAML mechanism provides identical functionality to calling the functions
+// directly.
 //
 // The YAML specification is show below and reflects the structure
 // (ie. is recursive) of the command tree to be created.

--- a/cmdutil/subcmd/subcmd.go
+++ b/cmdutil/subcmd/subcmd.go
@@ -65,29 +65,29 @@
 //
 // The FromYAML function provides a more convenient and readable means of creating
 // a command tree than using the NewCommand and NewCommandSet functions directly.
-// FromYAML reads a yaml specification of a command tree, its
-// summary documentation and argument specification and calls NewCommand
-// and NewCommandSet internally.
+// FromYAML reads a yaml specification of a command tree, its summary documentation
+// and argument specification and calls NewCommand and NewCommandSet internally.
 //
 // The returned CommandSetYAML type can then be used to 'decorate' the command
-// tree with the runner functions and flag value instances. This is more comprehensible
-// means of defining the command tree than doing so entirely via function calls.
-// The YAML mechanism provides identical functionality to calling the functions
-// directly.
+// tree with the runner functions and flag value instances. The YAML mechanism
+// provides identical functionality to calling the functions directly.
 //
-// The YAML specification is show below and reflects the structure
-// (ie. is recursive) of the command tree to be created.
+// The YAML specification is show below and reflects the tree structure
+// of the command tree to be created.
 //
-//	name: command-name
-//	summary: description of the command
-//	arguments:
-//	commands:
-//	  - name:
-//	    summary:
-//	    arguments:
-//	    commands:
+//		name: command-name
+//		summary: description of the command
+//		arguments:
+//		commands:
+//		  - name:
+//		    summary:
+//		    arguments:
+//		    commands:
+//	   - name:
+//	     summary:
+//	     ...
 //
-// The summary is displayed when the command's usage information is displayed.
+// The summary and argument values are used in calls in the Command.Document.
 // The arguments: field is a list of the expected arguments that also defines
 // the number of expected arguments.
 //
@@ -103,6 +103,15 @@
 //
 // To define a simple command line, with no sub-commands, specify only
 // the name:, summary: and arguments: fields.
+//
+// CommandSet.Dispatch implements support for requesting help information
+// on the top level and subcommands. Running a command with sub-commands
+// without specifying one of those sub-commands results in a 'usage' message
+// showing summary information and the available subcommands. Help on
+// a specific subcommand is available via '<command> help <sub-command>' or
+// for multi-level commands '<command> <sub-command> help <next-sub-command>'.
+// The --help flag can be used to display information on a commands
+// flags and arguments, eg: '<command> --help' or "<command> <sub-command> --help".
 //
 // Note that this package will never call flag.Parse and will not associate
 // any flags with flag.CommandLine.

--- a/cmdutil/subcmd/testdata/multilevel.go
+++ b/cmdutil/subcmd/testdata/multilevel.go
@@ -1,0 +1,94 @@
+// Copyright 2022 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"cloudeng.io/cmdutil/subcmd"
+)
+
+var (
+	cmdSet      *subcmd.CommandSet
+	globalFlags GlobalFlags
+)
+
+type GlobalFlags struct {
+	Flag1 int `subcmd:"flag1,1,flag1"`
+}
+
+type exampleFlags struct {
+	Flag1 int `subcmd:"flag1,1,flag1"`
+}
+
+func init() {
+	l0_1 := subcmd.NewCommand(
+		"l0.1",
+		subcmd.MustRegisteredFlagSet(&exampleFlags{}),
+		l0_1,
+		subcmd.ExactlyNumArguments(2))
+	l0_1.Document("summary of l0.1")
+	l0_2 := subcmd.NewCommand(
+		"l0.2",
+		subcmd.MustRegisteredFlagSet(&exampleFlags{}),
+		l0_2,
+		subcmd.AtLeastNArguments(1))
+	l0_2.Document("summary of l0.2")
+
+	l1_1 := subcmd.NewCommand(
+		"l1.1",
+		subcmd.MustRegisteredFlagSet(&exampleFlags{}),
+		l1_1,
+		subcmd.WithoutArguments())
+	l1_1.Document("describe l1.1")
+
+	l1_2 := subcmd.NewCommand(
+		"l1.2",
+		subcmd.MustRegisteredFlagSet(&exampleFlags{}),
+		l1_2,
+		subcmd.WithoutArguments())
+	l1_2.Document("describe l1.2")
+
+	l1 := subcmd.NewCommandLevel("l1", subcmd.NewCommandSet(l1_1, l1_2))
+	l1.Document("summary of l1")
+
+	cmdSet = subcmd.NewCommandSet(l0_1, l0_2, l1)
+	cmdSet.Document("summary of l0")
+
+	gfs := subcmd.GlobalFlagSet().MustRegisterFlagStruct(&globalFlags, nil, nil)
+	cmdSet.WithGlobalFlags(gfs)
+	cmdSet.WithMain(mainWrapper)
+}
+
+func runner(ctx context.Context, name string, values interface{}, args []string) error {
+	fmt.Printf("%s: flag value: %v\n", name, values.(*exampleFlags).Flag1)
+	return nil
+}
+
+func l0_1(ctx context.Context, values interface{}, args []string) error {
+	return runner(ctx, "l0_1", values, args)
+}
+
+func l0_2(ctx context.Context, values interface{}, args []string) error {
+	return runner(ctx, "l0_2", values, args)
+}
+
+func l1_1(ctx context.Context, values interface{}, args []string) error {
+	return runner(ctx, "l1_1", values, args)
+}
+
+func l1_2(ctx context.Context, values interface{}, args []string) error {
+	return runner(ctx, "l1_1", values, args)
+}
+
+func mainWrapper(ctx context.Context, cmdRunner func(ctx context.Context) error) error {
+	fmt.Printf("main wrapper: ")
+	return cmdRunner(ctx)
+}
+
+func main() {
+	cmdSet.MustDispatch(context.Background())
+}

--- a/cmdutil/subcmd/testdata/multilevel_yaml.go
+++ b/cmdutil/subcmd/testdata/multilevel_yaml.go
@@ -1,0 +1,85 @@
+// Copyright 2022 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"cloudeng.io/cmdutil/subcmd"
+)
+
+var globalFlags GlobalFlags
+
+type GlobalFlags struct {
+	Flag1 int `subcmd:"flag1,1,flag1"`
+}
+
+type exampleFlags struct {
+	Flag1 int `subcmd:"flag1,1,flag1"`
+}
+
+const multilevel = `name: l0
+summary: summary of l0
+commands:
+  - name: l0.1
+    summary: summary of l0.1
+    arguments:
+        - <arg1>
+        - <arg2>
+  - name: l0.2
+    summary: summary of l0.2
+  - name: l1
+    summary: summary of l1
+    commands:
+      - name: l1.1
+        summary: describe l1.1
+      - name: l1.2
+        summary: describe l1.2
+`
+
+var cmdSet *subcmd.CommandSetYAML = subcmd.MustFromYAML(multilevel)
+
+func init() {
+	cmdSet.Set("l0.1").RunnerAndFlags(l0_1, subcmd.MustRegisteredFlagSet(&exampleFlags{}))
+	cmdSet.Set("l0.2").RunnerAndFlags(l0_2, subcmd.MustRegisteredFlagSet(&exampleFlags{}))
+
+	cmdSet.Set("l1", "l1.1").RunnerAndFlags(l1_1, subcmd.MustRegisteredFlagSet(&exampleFlags{}))
+	cmdSet.Set("l1", "l1.2").RunnerAndFlags(l1_2, subcmd.MustRegisteredFlagSet(&exampleFlags{}))
+
+	gfs := subcmd.GlobalFlagSet().MustRegisterFlagStruct(&globalFlags, nil, nil)
+	cmdSet.WithGlobalFlags(gfs)
+	cmdSet.WithMain(mainWrapper)
+}
+
+func runner(ctx context.Context, name string, values interface{}, args []string) error {
+	fmt.Printf("%s: flag value: %v\n", name, values.(*exampleFlags).Flag1)
+	return nil
+}
+
+func l0_1(ctx context.Context, values interface{}, args []string) error {
+	return runner(ctx, "l0_1", values, args)
+}
+
+func l0_2(ctx context.Context, values interface{}, args []string) error {
+	return runner(ctx, "l0_2", values, args)
+}
+
+func l1_1(ctx context.Context, values interface{}, args []string) error {
+	return runner(ctx, "l1_1", values, args)
+}
+
+func l1_2(ctx context.Context, values interface{}, args []string) error {
+	return runner(ctx, "l1_1", values, args)
+}
+
+func mainWrapper(ctx context.Context, cmdRunner func(ctx context.Context) error) error {
+	fmt.Printf("main wrapper: ")
+	return cmdRunner(ctx)
+}
+
+func main() {
+	cmdSet.MustDispatch(context.Background())
+}

--- a/cmdutil/subcmd/testdata/onelevel.go
+++ b/cmdutil/subcmd/testdata/onelevel.go
@@ -1,0 +1,51 @@
+// Copyright 2022 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"cloudeng.io/cmdutil/subcmd"
+)
+
+var cmdSet *subcmd.CommandSet
+
+type exampleFlags struct {
+	Flag1 int `subcmd:"flag1,1,flag1"`
+}
+
+func init() {
+	l0_1 := subcmd.NewCommand(
+		"l0.1",
+		subcmd.MustRegisteredFlagSet(&exampleFlags{}),
+		l0_1,
+		subcmd.ExactlyNumArguments(2))
+	l0_1.Document("summary of l0.1")
+	l0_2 := subcmd.NewCommand(
+		"l0.2",
+		subcmd.MustRegisteredFlagSet(&exampleFlags{}),
+		l0_2,
+		subcmd.AtLeastNArguments(1))
+	l0_2.Document("summary of l0.2")
+	cmdSet = subcmd.NewCommandSet(l0_1, l0_2)
+	cmdSet.Document("describe l0")
+}
+
+func l0_1(ctx context.Context, values interface{}, args []string) error {
+	fv := values.(*exampleFlags)
+	fmt.Printf("l0_1: flag value: %v\n", fv.Flag1)
+	return nil
+}
+
+func l0_2(ctx context.Context, values interface{}, args []string) error {
+	fv := values.(*exampleFlags)
+	fmt.Printf("l0_2: flag value: %v\n", fv.Flag1)
+	return nil
+}
+
+func main() {
+	cmdSet.MustDispatch(context.Background())
+}

--- a/cmdutil/subcmd/testdata/onelevel_yaml.go
+++ b/cmdutil/subcmd/testdata/onelevel_yaml.go
@@ -1,0 +1,54 @@
+// Copyright 2022 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"cloudeng.io/cmdutil/subcmd"
+)
+
+const onelevel = `name: l0
+summary: describe l0
+commands:
+  - name: l0.1
+    summary: summary of l0.1
+    arguments:
+        - <arg1>
+        - <arg2>
+  - name: l0.2
+    summary: summary of l0.2
+    arguments:
+      - <arg1>
+      - ...
+`
+
+var cmdSet *subcmd.CommandSetYAML = subcmd.MustFromYAML(onelevel)
+
+type exampleFlags struct {
+	Flag1 int `subcmd:"flag1,1,flag1"`
+}
+
+func init() {
+	cmdSet.Set("l0.1").RunnerAndFlags(l0_1, subcmd.MustRegisteredFlagSet(&exampleFlags{}))
+	cmdSet.Set("l0.2").RunnerAndFlags(l0_2, subcmd.MustRegisteredFlagSet(&exampleFlags{}))
+}
+
+func l0_1(ctx context.Context, values interface{}, args []string) error {
+	fv := values.(*exampleFlags)
+	fmt.Printf("l0_1: flag value: %v\n", fv.Flag1)
+	return nil
+}
+
+func l0_2(ctx context.Context, values interface{}, args []string) error {
+	fv := values.(*exampleFlags)
+	fmt.Printf("l0_2: flag value: %v\n", fv.Flag1)
+	return nil
+}
+
+func main() {
+	cmdSet.MustDispatch(context.Background())
+}

--- a/cmdutil/subcmd/testdata/toplevel.go
+++ b/cmdutil/subcmd/testdata/toplevel.go
@@ -1,0 +1,44 @@
+// Copyright 2022 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"cloudeng.io/cmdutil/subcmd"
+)
+
+const simple = `name: simple
+usage: 
+`
+
+var cmdSet *subcmd.CommandSet
+
+type simpleFlags struct {
+	Flag1 int `subcmd:"flag1,1,flag1"`
+	Flag2 int `subcmd:"flag2,2,flag2"`
+}
+
+func init() {
+	toplevel := subcmd.NewCommand(
+		"simple",
+		subcmd.MustRegisteredFlagSet(&simpleFlags{}),
+		runner,
+		subcmd.WithoutArguments())
+	toplevel.Document("overall documentation for the simple command")
+	cmdSet = subcmd.NewCommandSet()
+	cmdSet.TopLevel(toplevel)
+}
+
+func runner(ctx context.Context, values interface{}, args []string) error {
+	fv := values.(*simpleFlags)
+	fmt.Printf("runner: flag values: %v %v\n", fv.Flag1, fv.Flag2)
+	return nil
+}
+
+func main() {
+	cmdSet.MustDispatch(context.Background())
+}

--- a/cmdutil/subcmd/testdata/toplevel_yaml.go
+++ b/cmdutil/subcmd/testdata/toplevel_yaml.go
@@ -1,0 +1,38 @@
+// Copyright 2022 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"cloudeng.io/cmdutil/subcmd"
+)
+
+const simple = `name: simple
+summary: overall documentation
+  for the simple command
+`
+
+var cmdSet *subcmd.CommandSetYAML = subcmd.MustFromYAML(simple)
+
+type simpleFlags struct {
+	Flag1 int `subcmd:"flag1,1,flag1"`
+	Flag2 int `subcmd:"flag2,2,flag2"`
+}
+
+func init() {
+	cmdSet.Set("simple").RunnerAndFlags(runner, subcmd.MustRegisteredFlagSet(&simpleFlags{}))
+}
+
+func runner(ctx context.Context, values interface{}, args []string) error {
+	fv := values.(*simpleFlags)
+	fmt.Printf("runner: flag values: %v %v\n", fv.Flag1, fv.Flag2)
+	return nil
+}
+
+func main() {
+	cmdSet.MustDispatch(context.Background())
+}


### PR DESCRIPTION
This PR provides for more readable and concise definition of command trees by using a YAML specification for defining the command tree, documentation and expected arguments for each command.