### PR TITLE
file,cmdutil: add FSReadFile, FSOpen and use them from ParseYAMLConfigFile.

### DIFF
--- a/cmdutil/yaml_util.go
+++ b/cmdutil/yaml_util.go
@@ -7,13 +7,14 @@ package cmdutil
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
 
+	"cloudeng.io/file"
 	"gopkg.in/yaml.v3"
 )
 
@@ -31,14 +32,18 @@ func ParseYAMLConfigString(spec string, cfg interface{}) error {
 	return ParseYAMLConfig([]byte(spec), cfg)
 }
 
-// ParseYAMLConfigFile reads a yaml config file as per ParseYAMLConfig.
-func ParseYAMLConfigFile(file string, cfg interface{}) error {
-	spec, err := os.ReadFile(file)
+// ParseYAMLConfigFile reads a yaml config file as per ParseYAMLConfig
+// using file.FSReadFile to read the file. The use of FSReadFile allows
+// for the configuration file to be read from storage system, including
+// from embed.FS, instead of the local filesystem if an instance of fs.ReadFileFS
+// is stored in the context.
+func ParseYAMLConfigFile(ctx context.Context, filename string, cfg interface{}) error {
+	spec, err := file.FSReadFile(ctx, filename)
 	if err != nil {
 		return err
 	}
 	if err := ParseYAMLConfig(spec, cfg); err != nil {
-		return fmt.Errorf("failed to parse %s: %w", file, err)
+		return fmt.Errorf("failed to parse %s: %w", filename, err)
 	}
 	return nil
 }

--- a/file/fs_read.go
+++ b/file/fs_read.go
@@ -1,0 +1,47 @@
+// Copyright 2023 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+package file
+
+import (
+	"context"
+	"io/fs"
+	"os"
+)
+
+type fsKey int
+
+var fsKeyVal fsKey
+
+// ContextWithFS returns a new context that contains the provided instance
+// of fs.ReadFileFS stored with as a valye within it.
+func ContextWithFS(ctx context.Context, container fs.ReadFileFS) context.Context {
+	return context.WithValue(ctx, fsKeyVal, container)
+}
+
+// FSFromContext returns the fs.ReadFileFS instance, if any,
+// stored within the context.
+func FSFromContext(ctx context.Context) (fs.ReadFileFS, bool) {
+	c, ok := ctx.Value(fsKeyVal).(fs.ReadFileFS)
+	return c, ok
+}
+
+// FSOpen will open name using the context's fs.ReadFileFS instance if
+// one is present, otherwise it will use os.Open.
+func FSOpen(ctx context.Context, name string) (fs.File, error) {
+	if fs, ok := FSFromContext(ctx); ok {
+		return fs.Open(name)
+	}
+	return os.Open(name)
+
+}
+
+// FSreadAll will read name using the context's fs.ReadFileFS instance if
+// one is present, otherwise it will use os.ReadFile.
+func FSReadFile(ctx context.Context, name string) ([]byte, error) {
+	if fs, ok := FSFromContext(ctx); ok {
+		return fs.ReadFile(name)
+	}
+	return os.ReadFile(name)
+}

--- a/file/fs_read_test.go
+++ b/file/fs_read_test.go
@@ -1,0 +1,60 @@
+// Copyright 2023 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+package file_test
+
+import (
+	"bytes"
+	"context"
+	"embed"
+	"io/fs"
+	"path"
+	"testing"
+
+	"cloudeng.io/file"
+)
+
+type container struct {
+	contents []byte
+}
+
+func (c *container) New() fs.ReadFileFS {
+	return &container{}
+}
+
+func (c *container) ReadFile(name string) ([]byte, error) {
+	return c.contents, nil
+}
+
+func (c *container) Open(name string) (fs.File, error) {
+	return nil, nil
+}
+
+//go:embed testdata/hello.txt
+var testFS embed.FS
+
+//go:embed testdata/hello.txt
+var testFSBytes []byte
+
+func TestOpenReadFile(t *testing.T) {
+	ctx := context.Background()
+
+	data, err := file.FSReadFile(ctx, path.Join("testdata", "hello.txt"))
+	if err != nil {
+		t.Error(err)
+	}
+	if got, want := data, testFSBytes; !bytes.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	dummy := &container{contents: []byte("dummy data\n")}
+	ctx = file.ContextWithFS(ctx, dummy)
+	data, err = file.FSReadFile(ctx, path.Join("testdata", "hello.txt"))
+	if err != nil {
+		t.Error(err)
+	}
+	if got, want := data, dummy.contents; !bytes.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/file/fs_read_test.go
+++ b/file/fs_read_test.go
@@ -7,7 +7,7 @@ package file_test
 import (
 	"bytes"
 	"context"
-	"embed"
+	_ "embed"
 	"io/fs"
 	"path"
 	"testing"
@@ -30,9 +30,6 @@ func (c *container) ReadFile(name string) ([]byte, error) {
 func (c *container) Open(name string) (fs.File, error) {
 	return nil, nil
 }
-
-//go:embed testdata/hello.txt
-var testFS embed.FS
 
 //go:embed testdata/hello.txt
 var testFSBytes []byte

--- a/file/testdata/hello.txt
+++ b/file/testdata/hello.txt
@@ -1,0 +1,1 @@
+hello testdata


### PR DESCRIPTION
FSReadFile, FSOpen extract an fs.ReadFileFS from the context and use that to read the requested file if present, otherwise they use os.Open and os.ReadFile. This allows for files to be located locally, remotely or embedded and be accessed via the same API. This is primarily intended for small, configuration and similar files.