### PR TITLE
cmdutil/subcmd: allow use of arg... as well as ... on its own

### DIFF
--- a/cmdutil/subcmd/extensions_test.go
+++ b/cmdutil/subcmd/extensions_test.go
@@ -5,7 +5,6 @@
 package subcmd_test
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -38,7 +37,6 @@ type extType struct {
 }
 
 func (e *extType) Set(cs *subcmd.CommandSetYAML) error {
-	fmt.Printf(">>>> %v\n", cs)
 	e.count++
 	return nil
 }

--- a/cmdutil/subcmd/extensions_test.go
+++ b/cmdutil/subcmd/extensions_test.go
@@ -36,7 +36,7 @@ type extType struct {
 	count int
 }
 
-func (e *extType) Set(cs *subcmd.CommandSetYAML) error {
+func (e *extType) Set(_ *subcmd.CommandSetYAML) error {
 	e.count++
 	return nil
 }

--- a/cmdutil/subcmd/subcmd.go
+++ b/cmdutil/subcmd/subcmd.go
@@ -95,8 +95,8 @@
 //
 //  2. If the list contains n arguments then exactly that number of arguments
 //     is expected, unless, the last argument in the list is '...' in which case
-//     at least that number is
-//     expected.
+//     at least that number is expected. Similarly if an argument ends in '...'
+//     then at least the preceding number of arguments is expected.
 //
 //  3. If there is a single item in the list and it is enclosed
 //     in [] (in a quoted string), then 0 or 1 arguments are expected.

--- a/cmdutil/subcmd/testdata/toplevel_yaml.go
+++ b/cmdutil/subcmd/testdata/toplevel_yaml.go
@@ -24,6 +24,7 @@ type simpleFlags struct {
 }
 
 func init() {
+	v
 	cmdSet.Set("simple").RunnerAndFlagSet(runner, subcmd.MustRegisteredFlagSet(&simpleFlags{}))
 }
 

--- a/cmdutil/subcmd/testdata/toplevel_yaml.go
+++ b/cmdutil/subcmd/testdata/toplevel_yaml.go
@@ -24,7 +24,6 @@ type simpleFlags struct {
 }
 
 func init() {
-	v
 	cmdSet.Set("simple").RunnerAndFlagSet(runner, subcmd.MustRegisteredFlagSet(&simpleFlags{}))
 }
 

--- a/cmdutil/subcmd/yaml.go
+++ b/cmdutil/subcmd/yaml.go
@@ -146,7 +146,7 @@ func determineOptForArgs(args []string) CommandOption {
 	if len(args) == 0 {
 		return WithoutArguments()
 	}
-	if args[len(args)-1] == "..." {
+	if args[len(args)-1] == "..." || strings.HasSuffix(args[len(args)-1], "...") {
 		return AtLeastNArguments(len(args) - 1)
 	}
 	if len(args) == 1 {

--- a/cmdutil/subcmd/yaml_internal_test.go
+++ b/cmdutil/subcmd/yaml_internal_test.go
@@ -16,6 +16,5 @@ func (c *CommandSetYAML) Usage(names ...string) string {
 		return cmd.Usage()
 	}
 	fmt.Printf("d: %v\n", c.cmdDict)
-	fmt.Printf(">>> %v\n", pathname)
 	return c.CommandSet.Usage(os.Args[0])
 }

--- a/cmdutil/subcmd/yaml_test.go
+++ b/cmdutil/subcmd/yaml_test.go
@@ -226,10 +226,14 @@ commands:
       - <arg1>
       - <arg2>
       - ...
+  - name: c7
+    arguments: # at least two
+      - <arg1>
+      - <opt>...
 `)
 
 	out := &strings.Builder{}
-	for _, name := range []string{"c1", "c2", "c3", "c4", "c5", "c6"} {
+	for _, name := range []string{"c1", "c2", "c3", "c4", "c5", "c6", "c7"} {
 		cmdSet.Set(name).MustRunner(
 			(&runner{name: name, out: out}).cmd,
 			&exampleFlags{})
@@ -268,6 +272,8 @@ commands:
 	}
 	err = cmdSet.DispatchWithArgs(context.Background(), os.Args[0], "c6", "1")
 	assertError("c6: accepts at least 2 arguments")
+	err = cmdSet.DispatchWithArgs(context.Background(), os.Args[0], "c7")
+	assertError("c7: accepts at least 1 argument")
 }
 
 func gorun(t *testing.T, file string, args []string) string {


### PR DESCRIPTION
This PR allows the use of ```- arg...``` to represent zero or more arguments in addition to the existing ```- ...```  which allows for at least n arguments.