### PR TITLE
cmdutil/profiling: set rate for block profile

### DIFF
--- a/cmdutil/profiling/profile.go
+++ b/cmdutil/profiling/profile.go
@@ -9,7 +9,9 @@ package profiling
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"runtime/pprof"
+	"strconv"
 	"strings"
 
 	"cloudeng.io/errors"
@@ -119,6 +121,13 @@ func Start(name, filename string) (func() error, error) {
 	if name == "cpu" {
 		save, err := enableCPUProfiling(filename)
 		return save, err
+	}
+	if name == "block" {
+		rate, _ := strconv.Atoi(os.Getenv("GO_BLOCK_PROFILE_RATE"))
+		if rate == 0 {
+			rate = 1000
+		}
+		runtime.SetBlockProfileRate(rate)
 	}
 	output, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0760)
 	if err != nil {


### PR DESCRIPTION
Make sure to call runtime.SetBlockProfileRate when a block profile is requested. The default value is 1000, but can set using the environment variable GO_BLOCK_PROFILE_RATE.