### PR TITLE
sync/synctestutil: call runtime.GC before gathering stacks for goroutines

### DIFF
--- a/sync/synctestutil/noleaks.go
+++ b/sync/synctestutil/noleaks.go
@@ -5,6 +5,7 @@
 package synctestutil
 
 import (
+	"runtime"
 	"time"
 
 	"cloudeng.io/debug/goroutines"
@@ -37,6 +38,7 @@ type Errorf interface {
 //		fn()
 //	}
 func AssertNoGoroutines(t Errorf) func() {
+	runtime.GC()
 	bycreator, err := getGoroutines()
 	if err != nil {
 		t.Errorf("NoLeaks: failed to parse goroutine output %v", err)
@@ -60,6 +62,7 @@ func AssertNoGoroutines(t Errorf) func() {
 // AssertNoGoroutinesRacy is like AssertNoGoroutines but allows for
 // a grace period for goroutines to terminate.
 func AssertNoGoroutinesRacy(t Errorf, wait time.Duration) func() {
+	runtime.GC()
 	bycreator, err := getGoroutines()
 	if err != nil {
 		t.Errorf("NoLeaks: failed to parse goroutine output %v", err)


### PR DESCRIPTION
Force a GC cycle before examining goroutine stacks to reduce test flakiness. It appears that if a linux system is slow (github test runners in particular) then a goroutine's stack may be still be returned by runtime.Stack even if that goroutine has terminated. This should help with that situation.