### PR TITLE
file/filewalk: remove async status reports, improve context cancelation

### DIFF
--- a/file/filewalk/localfs/local.go
+++ b/file/filewalk/localfs/local.go
@@ -36,6 +36,14 @@ func (s *scanner) Contents() []filewalk.Entry {
 }
 
 func (s *scanner) Scan(ctx context.Context, n int) bool {
+	// Check for ctx.Done() before performing any IO since
+	// readdir operations may be very slow.
+	select {
+	case <-ctx.Done():
+		s.err = ctx.Err()
+		return false
+	default:
+	}
 	if s.file == nil {
 		if !s.open(ctx, s.path) {
 			return false

--- a/file/filewalk/localfs/local.go
+++ b/file/filewalk/localfs/local.go
@@ -6,12 +6,10 @@ package localfs
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"time"
 
 	"cloudeng.io/file"
 	"cloudeng.io/file/filewalk"
@@ -73,20 +71,7 @@ type openState struct {
 }
 
 func (s *scanner) open(ctx context.Context, path string) bool {
-	ch := make(chan openState, 1)
-	go func() {
-		f, err := os.Open(path)
-		ch <- openState{file: f, err: err}
-	}()
-	select {
-	case <-ctx.Done():
-		s.err = ctx.Err()
-		return false
-	case state := <-ch:
-		s.file, s.err = state.file, state.err
-	case <-time.After(time.Minute):
-		s.err = fmt.Errorf("os.Open(%s) too too long", path)
-	}
+	s.file, s.err = os.Open(path)
 	return s.err == nil
 }
 

--- a/file/filewalk/localfs/local.go
+++ b/file/filewalk/localfs/local.go
@@ -65,12 +65,7 @@ func (s *scanner) Err() error {
 	return s.err
 }
 
-type openState struct {
-	file *os.File
-	err  error
-}
-
-func (s *scanner) open(ctx context.Context, path string) bool {
+func (s *scanner) open(_ context.Context, path string) bool {
 	s.file, s.err = os.Open(path)
 	return s.err == nil
 }

--- a/file/filewalk/walker_test.go
+++ b/file/filewalk/walker_test.go
@@ -364,7 +364,7 @@ func TestFunctionErrors(t *testing.T) {
 
 	wk = filewalk.New[int](sc, &errorScanner{contentsError: errors.New("oh no")}, filewalk.WithScanSize(1))
 	err = wk.Walk(ctx, localTestTree)
-	if err == nil || strings.Count(err.Error(), "oh no") != 2 {
+	if err == nil || strings.Count(err.Error(), "oh no") != 1 {
 		t.Errorf("missing or unexpected error: %v", err)
 	}
 

--- a/file/filewalk/walker_test.go
+++ b/file/filewalk/walker_test.go
@@ -352,7 +352,7 @@ func (e *errorScanner) Done(_ context.Context, _ *int, _ string, err error) erro
 }
 
 func TestFunctionErrors(t *testing.T) {
-	defer synctestutil.AssertNoGoroutines(t)()
+	defer synctestutil.AssertNoGoroutinesRacy(t, time.Second)()
 	ctx := context.Background()
 	sc := localfs.New()
 

--- a/file/filewalk/walker_test.go
+++ b/file/filewalk/walker_test.go
@@ -364,7 +364,7 @@ func TestFunctionErrors(t *testing.T) {
 
 	wk = filewalk.New[int](sc, &errorScanner{contentsError: errors.New("oh no")}, filewalk.WithScanSize(1))
 	err = wk.Walk(ctx, localTestTree)
-	if err == nil || strings.Count(err.Error(), "oh no") != 1 {
+	if err == nil || strings.Count(err.Error(), "oh no") != 2 {
 		t.Errorf("missing or unexpected error: %v", err)
 	}
 

--- a/file/filewalk/walker_test.go
+++ b/file/filewalk/walker_test.go
@@ -413,7 +413,7 @@ func (is *infiniteScanner) LevelScanner(_ string) filewalk.LevelScanner {
 }
 
 func TestCancel(t *testing.T) {
-	defer synctestutil.AssertNoGoroutinesRacy(t, time.Second)()
+	defer synctestutil.AssertNoGoroutines(t)()
 	ctx := context.Background()
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/file/filewalk/walker_test.go
+++ b/file/filewalk/walker_test.go
@@ -487,45 +487,21 @@ func (is *slowScanner) Contents() []filewalk.Entry {
 	return is.sc.Contents()
 }
 
-func TestReportingSlowScanner(t *testing.T) {
+func TestSyncScans(t *testing.T) {
 	defer synctestutil.AssertNoGoroutines(t)()
 	ctx := context.Background()
 	is := &slowFS{localfs.New()}
-	ch := make(chan filewalk.Status, 100)
 	lg := &logger{
 		fs:    is,
 		state: map[string]int{},
 	}
-	wk := filewalk.New[int](is, lg, filewalk.WithScanSize(1), filewalk.WithConcurrentScans(2),
-		filewalk.WithReporting(ch, time.Millisecond*100, time.Millisecond*250))
+	wk := filewalk.New[int](is, lg, filewalk.WithScanSize(1), filewalk.WithConcurrentScans(1))
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	go func() {
-		_ = wk.Walk(ctx, localTestTree)
-		wg.Done()
-	}()
-
-	nSlow := 0
-	nSync := int64(0)
-	for r := range ch {
-		if r.SlowPrefix != "" {
-			nSlow++
-			if r.ScanDuration < time.Millisecond*250 {
-				t.Errorf("scan duration too short: %v", r.ScanDuration)
-			}
-		}
-		nSync += r.SynchronousScans
+	_ = wk.Walk(ctx, localTestTree)
+	stats := wk.Stats()
+	if stats.SynchronousScans == 0 {
+		t.Errorf("no synchronous scans")
 	}
-
-	if nSlow <= 40 {
-		t.Errorf("not enough slow scans: %v", nSlow)
-	}
-	if nSync == 0 {
-		t.Errorf("no synchronous scans: %v", nSync)
-	}
-	wg.Wait()
 }
 
 type dbScanner struct {


### PR DESCRIPTION
The introduction of the 'state' type to the Handler makes it straightforward for the client to track timing information and hence the status callback can be removed and the walker simplified. In addition, the checks for context cancelation are relocated to prevent new traverses from being initiated after the context is being canceled to speed up returning from Walk when the context is canceled.