### PR TITLE
file/filewalk: bug fix for localfs

### DIFF
--- a/file/filewalk/asyncstat/issuer.go
+++ b/file/filewalk/asyncstat/issuer.go
@@ -136,7 +136,6 @@ func (is *T) Process(ctx context.Context, prefix string, entries []filewalk.Entr
 		return is.sync(ctx, prefix, entries)
 	}
 	return is.async(ctx, prefix, entries)
-
 }
 
 func (is *T) callStat(ctx context.Context, filename string) (file.Info, error) {

--- a/file/filewalk/localfs/local.go
+++ b/file/filewalk/localfs/local.go
@@ -36,6 +36,9 @@ func (s *scanner) Contents() []filewalk.Entry {
 }
 
 func (s *scanner) Scan(ctx context.Context, n int) bool {
+	if n == 0 {
+		return false
+	}
 	// Check for ctx.Done() before performing any IO since
 	// readdir operations may be very slow.
 	select {


### PR DESCRIPTION
Have Scan returns false if asked for 0 items since that is most likely due to a bug in the calling code. Arguably, it should always return true for this case, but leads to infinite loops rather than no data, so this seems preferable.