### PR TITLE
path/cloudpath: change S3 delimiter/separator handling

### DIFF
--- a/path/cloudpath/examples_test.go
+++ b/path/cloudpath/examples_test.go
@@ -28,8 +28,8 @@ func ExampleScheme() {
 		fmt.Printf("%v %q %q %q %q %q %q %c %v\n", local, scheme, host, region, volume, path, key, sep, parameters)
 	}
 	// Output:
-	// false "s3" "" "" "my-bucket" "my-bucket/object" "/object" / map[]
-	// false "GoogleCloudStorage" "storage.cloud.google.com" "" "bucket" "/bucket/obj" "/obj" / map[]
+	// false "s3" "" "" "my-bucket" "my-bucket/object" "object" / map[]
+	// false "GoogleCloudStorage" "storage.cloud.google.com" "" "bucket" "/bucket/obj" "obj" / map[]
 	// false "GoogleCloudStorage" "" "" "my-bucket" "my-bucket" "" / map[]
 	// true "windows" "" "" "c" "c:\\root\\file" "\\root\\file" \ map[]
 }

--- a/path/cloudpath/fileuri.go
+++ b/path/cloudpath/fileuri.go
@@ -5,6 +5,7 @@
 package cloudpath
 
 import (
+	"bytes"
 	"strings"
 )
 
@@ -33,25 +34,25 @@ func parseFileURI(p string) (host, rest, drive string) {
 }
 
 // return the bucket and key from /bucket/key...
-func bucketAndKey(path string) (bucket, key string) {
+func bucketAndKey(path string, sep byte) (bucket, key string) {
 	p := path
 	switch len(path) {
 	case 0:
 		return
 	case 1:
-		if path[0] == '/' {
+		if path[0] == sep {
 			return
 		}
 	default:
-		if path[0] == '/' {
+		if path[0] == sep {
 			p = p[1:]
 		}
 	}
 	// p is now bucket/key...
-	idx := strings.Index(p, "/")
+	idx := bytes.Index([]byte(p), []byte{sep})
 	if idx < 0 {
 		bucket = p
 		return
 	}
-	return p[:idx], p[idx:]
+	return p[:idx], p[idx+1:] // drop the leading sep from key.
 }

--- a/path/cloudpath/google.go
+++ b/path/cloudpath/google.go
@@ -19,7 +19,7 @@ func GoogleCloudStorageMatcher(p string) Match {
 	}
 	if len(p) >= 5 && p[0:5] == "gs://" {
 		m.Path = p[5:]
-		m.Volume, m.Key = bucketAndKey(m.Path)
+		m.Volume, m.Key = bucketAndKey(m.Path, byte(m.Separator))
 		return m
 	}
 	u, err := url.Parse(p)
@@ -39,7 +39,7 @@ func GoogleCloudStorageMatcher(p string) Match {
 		return Match{}
 	case "storage.cloud.google.com":
 		// https://storage.cloud.google.com/[BUCKET_NAME]/[OBJECT_NAME]
-		m.Volume, m.Key = bucketAndKey(u.Path)
+		m.Volume, m.Key = bucketAndKey(u.Path, byte(m.Separator))
 		return m
 	case "storage.googleapis.com":
 		/*
@@ -59,7 +59,7 @@ func GoogleCloudStorageMatcher(p string) Match {
 		default:
 			return Match{}
 		case "/":
-			m.Volume, m.Key = bucketAndKey(m.Path)
+			m.Volume, m.Key = bucketAndKey(m.Path, byte(m.Separator))
 		case "/download/":
 			oidx := strings.Index(m.Path, "/o/")
 			if oidx < 0 {

--- a/path/cloudpath/google_test.go
+++ b/path/cloudpath/google_test.go
@@ -73,7 +73,7 @@ func TestGoogleCloudStorage(t *testing.T) {
 			cloudpath.GoogleCloudStorage, "storage.googleapis.com", "", "", "/", "", '/', nil,
 		},
 	}
-	if err := testMatcher(cloudpath.GoogleCloudStorageMatcher, data[:]); err != nil {
+	if err := testMatcher(cloudpath.GoogleCloudStorageMatcher, data); err != nil {
 		t.Errorf("%v", err)
 	}
 

--- a/path/cloudpath/google_test.go
+++ b/path/cloudpath/google_test.go
@@ -22,23 +22,23 @@ func TestGoogleCloudStorage(t *testing.T) {
 		},
 		{
 			"gs://bucket/",
-			cloudpath.GoogleCloudStorage, "", "", "bucket", "bucket/", "/", '/', nil,
+			cloudpath.GoogleCloudStorage, "", "", "bucket", "bucket/", "", '/', nil,
 		},
 		{
 			"gs://bucket/object",
-			cloudpath.GoogleCloudStorage, "", "", "bucket", "bucket/object", "/object", '/', nil,
+			cloudpath.GoogleCloudStorage, "", "", "bucket", "bucket/object", "object", '/', nil,
 		},
 		{
 			"gs://bucket/object/",
-			cloudpath.GoogleCloudStorage, "", "", "bucket", "bucket/object/", "/object/", '/', nil,
+			cloudpath.GoogleCloudStorage, "", "", "bucket", "bucket/object/", "object/", '/', nil,
 		},
 		{
 			"https://storage.cloud.google.com/bucket/path",
-			cloudpath.GoogleCloudStorage, "storage.cloud.google.com", "", "bucket", "/bucket/path", "/path", '/', nil,
+			cloudpath.GoogleCloudStorage, "storage.cloud.google.com", "", "bucket", "/bucket/path", "path", '/', nil,
 		},
 		{
 			"https://storage.cloud.google.com/bucket/path?a=b&c=d",
-			cloudpath.GoogleCloudStorage, "storage.cloud.google.com", "", "bucket", "/bucket/path", "/path", '/', exampleParameters,
+			cloudpath.GoogleCloudStorage, "storage.cloud.google.com", "", "bucket", "/bucket/path", "path", '/', exampleParameters,
 		},
 		{
 			"https://storage.cloud.google.com",
@@ -54,11 +54,11 @@ func TestGoogleCloudStorage(t *testing.T) {
 		},
 		{
 			"https://storage.cloud.google.com/bucket/",
-			cloudpath.GoogleCloudStorage, "storage.cloud.google.com", "", "bucket", "/bucket/", "/", '/', nil,
+			cloudpath.GoogleCloudStorage, "storage.cloud.google.com", "", "bucket", "/bucket/", "", '/', nil,
 		},
 		{
 			"https://storage.googleapis.com/storage/v1/b/bucket/path",
-			cloudpath.GoogleCloudStorage, "storage.googleapis.com", "", "bucket", "/bucket/path", "/path", '/', nil,
+			cloudpath.GoogleCloudStorage, "storage.googleapis.com", "", "bucket", "/bucket/path", "path", '/', nil,
 		},
 		{
 			"https://storage.googleapis.com/download/storage/v1/b/bucket/o/path",
@@ -73,7 +73,7 @@ func TestGoogleCloudStorage(t *testing.T) {
 			cloudpath.GoogleCloudStorage, "storage.googleapis.com", "", "", "/", "", '/', nil,
 		},
 	}
-	if err := testMatcher(cloudpath.GoogleCloudStorageMatcher, data[14:]); err != nil {
+	if err := testMatcher(cloudpath.GoogleCloudStorageMatcher, data[:]); err != nil {
 		t.Errorf("%v", err)
 	}
 

--- a/path/cloudpath/matchers_test.go
+++ b/path/cloudpath/matchers_test.go
@@ -34,7 +34,7 @@ func TestMatch(t *testing.T) {
 		},
 		{
 			"s3://my-bucket/files-on-s3",
-			cloudpath.AWSS3, "", "", "my-bucket", "my-bucket/files-on-s3", "/files-on-s3", '/', nil,
+			cloudpath.AWSS3, "", "", "my-bucket", "my-bucket/files-on-s3", "files-on-s3", '/', nil,
 		},
 		{
 			"/a/b",
@@ -54,7 +54,7 @@ func TestMatch(t *testing.T) {
 		},
 		{
 			"gs://bucket/object",
-			cloudpath.GoogleCloudStorage, "", "", "bucket", "bucket/object", "/object", '/', nil,
+			cloudpath.GoogleCloudStorage, "", "", "bucket", "bucket/object", "object", '/', nil,
 		},
 		{
 			"file:///a/b/c/",

--- a/path/cloudpath/s3_test.go
+++ b/path/cloudpath/s3_test.go
@@ -31,15 +31,15 @@ func TestS3(t *testing.T) {
 		},
 		{
 			"https://s3.us-west-2.amazonaws.com/mybucket/puppy.jpg",
-			cloudpath.AWSS3, "s3.us-west-2.amazonaws.com", "us-west-2", "mybucket", "/mybucket/puppy.jpg", "/puppy.jpg", '/', nil,
+			cloudpath.AWSS3, "s3.us-west-2.amazonaws.com", "us-west-2", "mybucket", "/mybucket/puppy.jpg", "puppy.jpg", '/', nil,
 		},
 		{
 			"https://my.bucket.s3.us-west-2.amazonaws.com/kitten.png",
-			cloudpath.AWSS3, "my.bucket.s3.us-west-2.amazonaws.com", "us-west-2", "my.bucket", "/kitten.png", "/kitten.png", '/', nil,
+			cloudpath.AWSS3, "my.bucket.s3.us-west-2.amazonaws.com", "us-west-2", "my.bucket", "/kitten.png", "kitten.png", '/', nil,
 		},
 		{
 			"s3://my-bucket/files-on-s3",
-			cloudpath.AWSS3, "", "", "my-bucket", "my-bucket/files-on-s3", "/files-on-s3", '/', nil,
+			cloudpath.AWSS3, "", "", "my-bucket", "my-bucket/files-on-s3", "files-on-s3", '/', nil,
 		},
 		{
 			"s3://",
@@ -51,7 +51,7 @@ func TestS3(t *testing.T) {
 		},
 		{
 			"s3://b/",
-			cloudpath.AWSS3, "", "", "b", "b/", "/", '/', nil,
+			cloudpath.AWSS3, "", "", "b", "b/", "", '/', nil,
 		},
 	}
 	if err := testMatcher(cloudpath.AWSS3Matcher, data); err != nil {


### PR DESCRIPTION
Allow for different separators for S3 and remove the leading separator for keys for S3 and GS to make it easier to
directly use the returned .Key value with the APIs for S3 and GS.