### PR TITLE
path/cloudpath: add Join, Basename, Prefix functions

### DIFF
--- a/path/cloudpath/cloud_join.go
+++ b/path/cloudpath/cloud_join.go
@@ -1,0 +1,94 @@
+// Copyright 2024 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+package cloudpath
+
+import (
+	"strings"
+)
+
+// Join will join the supplied components using the supplied separator
+// behaviour appropriate for cloud storage paths that do not elide multiple
+// contiguous separators. It behaves as follows:
+//   - empty components are ignored.
+//   - trailing instances of sep are preserved.
+//   - separators are added only when not already present as a trailing
+//     character in the previous component and leading character in the
+//     next component.
+//   - a leading separator is ignored/removed if the previous component
+//     ended with a separator and the next component starts with a separator.
+func Join(sep byte, components []string) string {
+	size := 0
+	for _, c := range components {
+		size += len(c)
+	}
+	if size == 0 {
+		return ""
+	}
+	joined := make([]byte, 0, size+len(components)-1)
+	for _, c := range components {
+		if len(c) == 0 {
+			continue
+		}
+		if lj := len(joined); lj > 0 {
+			ts := joined[lj-1] == sep
+			ls := c[0] == sep
+			if !ts && !ls {
+				joined = append(joined, sep)
+			}
+			if ls && ts {
+				c = c[1:]
+			}
+		}
+		joined = append(joined, c...)
+	}
+	return string(joined)
+}
+
+func lastIdx(scheme string, sep byte, path string) int {
+	idx := strings.LastIndexByte(path, sep)
+	if idx < 0 {
+		return -1
+	}
+	if idx <= len(scheme) && strings.HasPrefix(path, scheme) {
+		return -2
+	}
+	return idx
+}
+
+// Base is like path.Base but for cloud storage paths which may include
+// a scheme (eg. s3://). It does not support URI host names, parameters etc.
+// In particular:
+//   - the scheme parameter should include the trailing :// or be the
+//     empty string.
+//   - a trailing seperator means that the path is a prefix with
+//     an empty base and hence Base returns "".
+//   - the returned basename never includes the supplied scheme.
+func Base(scheme string, seperator byte, path string) string {
+	p := strings.TrimPrefix(path, scheme)
+	idx := strings.LastIndexByte(p, seperator)
+	if idx < 0 {
+		return path
+	}
+	return p[idx+1:]
+}
+
+// Prefix is like path.Dir but for cloud storage paths which may include
+// a scheme (eg. s3:///). It does not support URI host names, parameters etc.
+// In particular:
+//   - the scheme parameter should include the trailing :// or be the
+//     empty string.
+//   - the returned prefix never includes the supplied scheme.
+//   - the returned prefix never includes a trailing seperator.
+func Prefix(scheme string, seperator byte, path string) string {
+	p := strings.TrimPrefix(path, scheme)
+	if len(p) > 0 && p[len(p)-1] == seperator {
+		p = p[:len(p)-1] // already a prefix
+		return p
+	}
+	if idx := strings.LastIndexByte(p, seperator); idx >= 0 {
+		return p[:idx]
+	}
+	return ""
+}

--- a/path/cloudpath/cloud_join_test.go
+++ b/path/cloudpath/cloud_join_test.go
@@ -1,0 +1,113 @@
+// Copyright 2024 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+package cloudpath_test
+
+import (
+	"slices"
+	"testing"
+
+	"cloudeng.io/path/cloudpath"
+)
+
+func TestJoin(t *testing.T) {
+	j := func(p ...string) []string {
+		return p
+	}
+	var sep byte = '/'
+	for _, tc := range []struct {
+		in  []string
+		out string
+	}{
+		{j(), ""},
+		{j(""), ""},
+		{j("", ""), ""},
+		{j("", "b"), "b"},
+		{j("/", ""), "/"},
+		{j("a", ""), "a"},
+		{j("a", "b"), "a/b"},
+		{j("a", "b/"), "a/b/"},
+		{j("a/", "b"), "a/b"},
+		{j("a", "/b"), "a/b"},
+		{j("a/", "/b"), "a/b"},
+		{j("a", "", "b"), "a/b"},
+		{j("a/", "", "b"), "a/b"},
+		{j("a", "", "/b"), "a/b"},
+		{j("a/", "", "/b"), "a/b"},
+		{j("a/", "", "/b/"), "a/b/"},
+		{j("a/", ""), "a/"},
+	} {
+		if got, want := cloudpath.Join(sep, tc.in), tc.out; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestBasePrefix(t *testing.T) {
+	var sep byte = '/'
+	for _, scheme := range []string{"", "http://", "s3://"} {
+		for _, tc := range []struct {
+			in           string
+			prefix, base string
+		}{
+			{"", "", ""},
+			{"a", "", "a"},
+			{"a/", "a", ""},
+			{"a/b", "a", "b"},
+			{"a/b/", "a/b", ""},
+			{"a/b/c", "a/b", "c"},
+		} {
+			prefix := cloudpath.Prefix(scheme, sep, tc.in)
+			basename := cloudpath.Base(scheme, sep, tc.in)
+			if got, want := prefix, tc.prefix; got != want {
+				t.Errorf("%q (%v): got %v, want %v", tc.in, scheme, got, want)
+			}
+			if got, want := basename, tc.base; got != want {
+				t.Errorf("%q (%v): got %v, want %v", tc.in, scheme, got, want)
+			}
+
+			jp := prefix
+			if len(jp) > 0 {
+				jp += string(sep)
+			}
+			if got, want := cloudpath.Join(sep, []string{jp, basename}), tc.in; got != want {
+				t.Errorf("%q (%v) join(%q %q): got %v, want %v", tc.in, scheme, jp, basename, got, want)
+			}
+		}
+	}
+
+	parents := []string{}
+	children := []string{}
+	start := "s3://bucket/a/b/c/d/object"
+	p := start
+	for {
+		c := cloudpath.Base("s3://", '/', p)
+		p = cloudpath.Prefix("s3://", '/', p)
+		parents = append(parents, p)
+		children = append(children, c)
+		if len(p) == 0 {
+			break
+		}
+	}
+	if got, want := parents, []string{
+		"bucket/a/b/c/d",
+		"bucket/a/b/c",
+		"bucket/a/b",
+		"bucket/a",
+		"bucket",
+		"",
+	}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := children, []string{
+		"object",
+		"d",
+		"c",
+		"b",
+		"a",
+		"bucket",
+	}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Add Join, Basename and Prefix functions that are more appropriate for cloud-based storage systems such as S3 or GS.
