### PR TITLE
file/content: create a simple object store for file.Content objects.

### DIFF
--- a/file/content/object.go
+++ b/file/content/object.go
@@ -11,11 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 )
 
-// Object represents the result of object/file download/crawl operation. As such
+// Object represents the result of an object/file download/crawl operation. As such
 // it contains both the value that was downloaded and the result of the operation.
 // The Value field represents the typed value of the result of the download
 // or API operation. The Response field is the actual response for the download,
@@ -178,47 +176,6 @@ func (o *Object[V, R]) Decode(data []byte) error {
 		return fmt.Errorf("unsupported value encoding: %v", responseEncoding)
 	}
 	return err
-}
-
-// WriteObject will encode the object using the requested encoding to the
-// specified file. It will create the directory that the file is to be written
-// to if it does not exist.
-func (o *Object[V, R]) WriteObjectFile(path string, valueEncoding, responseEncoding ObjectEncoding) error {
-	buf, err := o.Encode(valueEncoding, responseEncoding)
-	if err != nil {
-		return err
-	}
-	wr, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-		// Try to create the directory that the file is to be written to.
-		os.MkdirAll(filepath.Dir(path), 0700) //nolint:errcheck
-		wr, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0600)
-		if err != nil {
-			return err
-		}
-	}
-	defer wr.Close()
-	_, err = wr.Write(buf)
-	return err
-}
-
-// ReadObjectFile will read the specified file and return the object type, encoding and the
-// the contents of that file. The returned byte slice can be used to decode the object using
-// its Decode method.
-func ReadObjectFile(path string) (Type, []byte, error) {
-	buf, err := os.ReadFile(path)
-	if err != nil {
-		return "", nil, err
-	}
-	rd := bytes.NewReader(buf)
-	data, err := readSlice(rd)
-	if err != nil {
-		return "", nil, err
-	}
-	return Type(data), buf, err
 }
 
 // Error is an implementation of error that is registered with the gob

--- a/file/content/store.go
+++ b/file/content/store.go
@@ -19,22 +19,22 @@ import (
 // that root. It is intended to be backed by either a local or cloud
 // filesystem.
 type Store[Value, Response any] struct {
-	fs                              ContentFS
+	fs                              FS
 	valueEncoding, responseEncoding ObjectEncoding
 	root                            string
 	written                         int64
 	read                            int64
 }
 
-type ContentFS interface {
+type FS interface {
 	file.ObjectFS
 	file.FS
 }
 
 // NewStore returns a new instance of Store backed by the supplied
-// ContentFS and storing the specified objects encoded using the
+// content.FS and storing the specified objects encoded using the
 // specified encodings.
-func NewStore[V, R any](fs ContentFS, path string, valueEncoding, responseEncoding ObjectEncoding) *Store[V, R] {
+func NewStore[V, R any](fs FS, path string, valueEncoding, responseEncoding ObjectEncoding) *Store[V, R] {
 	return &Store[V, R]{
 		fs:               fs,
 		root:             path,

--- a/file/content/store.go
+++ b/file/content/store.go
@@ -1,0 +1,99 @@
+// Copyright 2024 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+package content
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"cloudeng.io/file"
+)
+
+// Store represents a store for objects. It uses an instance of content.FS
+// to store and retrieve objects. The objects are stored in a hierarchy
+// at the specified root prefix/path and all operations are relative to
+// that root. It is intended to be backed by either a local or cloud
+// filesystem.
+type Store[Value, Response any] struct {
+	fs                              ContentFS
+	valueEncoding, responseEncoding ObjectEncoding
+	root                            string
+	written                         int64
+	read                            int64
+}
+
+type ContentFS interface {
+	file.ObjectFS
+	file.FS
+}
+
+// NewStore returns a new instance of Store backed by the supplied
+// ContentFS and storing the specified objects encoded using the
+// specified encodings.
+func NewStore[V, R any](fs ContentFS, path string, valueEncoding, responseEncoding ObjectEncoding) *Store[V, R] {
+	return &Store[V, R]{
+		fs:               fs,
+		root:             path,
+		valueEncoding:    valueEncoding,
+		responseEncoding: responseEncoding,
+	}
+}
+
+// EraseExisting deletes all existing contents of the store,
+// ie. all objects beneath the root prefix.
+func (s *Store[V, R]) EraseExisting(ctx context.Context) error {
+	if err := s.fs.DeleteAll(ctx, s.root); err != nil {
+		return fmt.Errorf("failed to delete store contents at %v: %v", s.root, err)
+	}
+	return nil
+}
+
+func (s *Store[V, R]) Store(ctx context.Context, prefix, name string, obj Object[V, R]) error {
+	buf, err := obj.Encode(s.valueEncoding, s.responseEncoding)
+	if err != nil {
+		return err
+	}
+	prefix = s.fs.Join(s.root, prefix)
+	path := s.fs.Join(prefix, name)
+	if err := s.fs.Put(ctx, path, 0600, buf); err != nil {
+		if !s.fs.IsNotExist(err) {
+			return err
+		}
+		if err := s.fs.EnsurePrefix(ctx, prefix, 0700); err != nil {
+			return err
+		}
+		if err := s.fs.Put(ctx, path, 0600, buf); err != nil {
+			return err
+		}
+	}
+	atomic.AddInt64(&s.written, 1)
+	return nil
+}
+
+func (s *Store[V, R]) Progress() (written, read int64) {
+	return atomic.LoadInt64(&s.read), atomic.LoadInt64(&s.written)
+}
+
+func (s *Store[V, R]) Load(ctx context.Context, prefix, name string) (Type, Object[V, R], error) {
+	var obj Object[V, R]
+	path := s.fs.Join(s.root, prefix, name)
+	buf, err := s.fs.Get(ctx, path)
+	if err != nil {
+		return "", obj, err
+	}
+	rd := bytes.NewReader(buf)
+	typ, err := readSlice(rd)
+	if err != nil {
+		return "", obj, err
+	}
+
+	if err := obj.Decode(buf); err != nil {
+		return Type(typ), obj, err
+	}
+	atomic.AddInt64(&s.read, 1)
+	return Type(typ), obj, nil
+}

--- a/file/content/store_test.go
+++ b/file/content/store_test.go
@@ -1,0 +1,94 @@
+// Copyright 2024 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+package content_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"cloudeng.io/file"
+	"cloudeng.io/file/content"
+)
+
+func mkdirall(t *testing.T, paths ...string) {
+	t.Helper()
+	err := os.MkdirAll(filepath.Join(paths...), 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStore(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	fs := file.LocalFS()
+
+	root := fs.Join(tmpDir, "store")
+	mkdirall(t, root)
+	mkdirall(t, root, "other")
+	mkdirall(t, root, "l1")
+	mkdirall(t, root, "l1", "l2")
+	if _, err := fs.Stat(ctx, root); err != nil {
+		t.Fatal(err)
+	}
+
+	store := content.NewStore[string, int](fs, root, content.JSONObjectEncoding, content.JSONObjectEncoding)
+
+	if err := store.EraseExisting(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := fs.Stat(ctx, root)
+	if err == nil || !fs.IsNotExist(err) {
+		t.Errorf("expected not to exist: %v", err)
+	}
+
+	obj := content.Object[string, int]{
+		Value:    "test",
+		Response: 1,
+		Type:     content.Type("test"),
+	}
+
+	prefix := fs.Join("a", "b")
+	path := fs.Join(root, prefix, "c")
+	if err := store.Store(ctx, prefix, "c", obj); err != nil {
+		t.Fatal(err)
+	}
+
+	read, written := store.Progress()
+	if got, want := read, int64(0); got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := written, int64(1); got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	if _, err := fs.Stat(ctx, path); err != nil {
+		t.Fatal(err)
+	}
+
+	ctype, obj1, err := store.Load(ctx, prefix, "c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := ctype, obj.Type; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := obj1, obj; !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	read, written = store.Progress()
+	if got, want := read, int64(1); got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := written, int64(1); got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+}


### PR DESCRIPTION
The object store uses instances of ContentFS to read/write objects and hence can be backed by local or cloud filesystems.