### PR TITLE
aws/s3fs: stat validates a prefix by calling ListPrefix on it

### DIFF
--- a/aws/s3fs/s3fs.go
+++ b/aws/s3fs/s3fs.go
@@ -114,7 +114,7 @@ func (s3fs *T) OpenCtx(ctx context.Context, name string) (fs.File, error) {
 		obj:    res,
 		bucket: match.Volume,
 		key:    key,
-		delim:  s3fs.options.delimiter,
+		delim:  string(s3fs.options.delimiter),
 		client: s3fs.client,
 		isDir:  key[len(key)-1] == s3fs.options.delimiter,
 	}, nil
@@ -133,10 +133,7 @@ func (s3fs *T) Stat(ctx context.Context, name string) (file.Info, error) {
 	if len(match.Matched) == 0 {
 		return file.Info{}, fmt.Errorf("invalid s3 path: %v", name)
 	}
-	if isPrefix(match.Key, s3fs.options.delimiter) {
-		return prefixFileInfo(match.Key, s3fs.options.delimiter), nil
-	}
-	return objectOrPrefixStat(ctx, s3fs.client, match.Volume, match.Key, s3fs.options.delimiter)
+	return statObjectOrPrefix(ctx, s3fs.client, match.Volume, match.Key, string(s3fs.options.delimiter))
 }
 
 func (s3fs *T) Lstat(ctx context.Context, path string) (file.Info, error) {
@@ -166,7 +163,8 @@ func (s3fs *T) IsPermissionError(err error) bool {
 func (s3fs *T) IsNotExist(err error) bool {
 	var nsk *types.NoSuchKey
 	var nsb *types.NoSuchBucket
-	return errors.As(err, &nsk) || errors.As(err, &nsb)
+	var nf *types.NotFound
+	return errors.As(err, &nf) || errors.As(err, &nsk) || errors.As(err, &nsb)
 }
 
 type s3xattr struct {
@@ -190,18 +188,20 @@ func (s3fs *T) SysXAttr(existing any, merge file.XAttr) any {
 }
 
 type s3Readble struct {
-	obj         *s3.GetObjectOutput
-	isDir       bool
-	client      Client
-	bucket, key string
-	delim       byte
+	obj    *s3.GetObjectOutput
+	isDir  bool
+	client Client
+	bucket string
+	key    string
+	delim  string
 }
 
 func (f *s3Readble) Stat() (fs.FileInfo, error) {
+	ctx := context.Background()
 	if f.isDir {
-		return prefixFileInfo(f.key, f.delim), nil
+		return listPrefixThenHead(ctx, f.client, f.bucket, f.key, f.delim)
 	}
-	return objectOrPrefixStat(context.Background(), f.client, f.bucket, f.key, f.delim)
+	return headThenListPrefix(ctx, f.client, f.bucket, f.key, f.delim)
 }
 
 func (f *s3Readble) Read(p []byte) (int, error) {

--- a/aws/s3fs/s3fs_test.go
+++ b/aws/s3fs/s3fs_test.go
@@ -141,20 +141,25 @@ func TestStat(t *testing.T) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	info, err = fs.Stat(ctx, "s3://bucket-a/x/y")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got, want := info.Name(), "y/"; got != want {
-		t.Errorf("got %v, want %v", got, want)
+	for _, p := range []string{"s3://bucket-b/x/y", "s3://bucket-b/x/y"} {
+		info, err = fs.Stat(ctx, p)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if got, want := info.Name(), "y/"; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		if got, want := info.IsDir(), true; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
 	}
 
-	info, err = fs.Stat(ctx, "s3://bucket-a/x/y/")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got, want := info.Name(), "y/"; got != want {
-		t.Errorf("got %v, want %v", got, want)
+	for _, p := range []string{"s3://bucket-a/does-not-exist", "s3://bucket-a/not-there/", "s3://bucket-a/not-there/or here"} {
+		_, err = fs.Stat(ctx, p)
+		if !fs.IsNotExist(err) {
+			t.Errorf("unexpected or missing error: %v", err)
+		}
 	}
 
 }

--- a/aws/s3fs/s3fs_test.go
+++ b/aws/s3fs/s3fs_test.go
@@ -140,6 +140,23 @@ func TestStat(t *testing.T) {
 	if got, want := info.Name(), "0"; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
+
+	info, err = fs.Stat(ctx, "s3://bucket-a/x/y")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := info.Name(), "y/"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	info, err = fs.Stat(ctx, "s3://bucket-a/x/y/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := info.Name(), "y/"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
 }
 
 func TestWalk(t *testing.T) {

--- a/aws/s3fs/s3ops.go
+++ b/aws/s3fs/s3ops.go
@@ -9,11 +9,14 @@ import (
 	"fmt"
 	"io/fs"
 	"sync"
+	"time"
 
+	"cloudeng.io/errors"
 	"cloudeng.io/file"
 	"cloudeng.io/path/cloudpath"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 // Client represents the set of AWS S3 client methods used by s3fs.
@@ -35,10 +38,36 @@ func objectHead(ctx context.Context, client Client, bucket, key *string) (*s3.He
 	return client.HeadObject(ctx, &req)
 }
 
-func objectStat(ctx context.Context, client Client, match cloudpath.Match) (file.Info, error) {
-	bucket := match.Volume
+func prefixStat(ctx context.Context, client Client, bucket, key string, delim byte) (file.Info, error) {
+	req := s3.ListObjectsV2Input{
+		Bucket:            aws.String(bucket),
+		Prefix:            aws.String(key),
+		ContinuationToken: nil,
+		Delimiter:         aws.String(string(delim)),
+		MaxKeys:           aws.Int32(1),
+	}
+	_, err := client.ListObjectsV2(ctx, &req)
+	if err != nil {
+		return file.Info{}, err
+	}
+	return prefixFileInfo(key, delim), nil
+}
+
+func isPrefix(key string, delim byte) bool {
+	return len(key) > 0 && key[len(key)-1] == delim
+}
+
+func prefixFileInfo(key string, delim byte) file.Info {
+	if lk := len(key); lk > 0 && key[lk-1] == delim {
+		key = key[:lk-1]
+	}
+	name := cloudpath.Base("s3://", delim, key) + string(delim)
+	return file.NewInfo(name, 0, fs.ModeDir, time.Time{}, nil)
+}
+
+func objectOrPrefixStat(ctx context.Context, client Client, bucket, key string, delim byte) (file.Info, error) {
 	awsBucket := aws.String(bucket)
-	awsKey := aws.String(match.Key)
+	awsKey := aws.String(key)
 
 	acl, err := bucketAcls.get(ctx, client, bucket)
 	if err != nil {
@@ -47,19 +76,19 @@ func objectStat(ctx context.Context, client Client, match cloudpath.Match) (file
 
 	head, err := objectHead(ctx, client, awsBucket, awsKey)
 	if err != nil {
+		var nf *types.NotFound
+		if errors.As(err, &nf) {
+			return prefixStat(ctx, client, bucket, key, delim)
+		}
 		return file.Info{}, err
 	}
 
 	var mode fs.FileMode
-	if match.Key[len(match.Key)-1] == '/' {
-		mode = fs.ModeDir
-	}
 	var xattr s3xattr
 	xattr.owner = aws.ToString(acl.Owner.ID)
 	xattr.obj = head
-
 	info := file.NewInfo(
-		cloudpath.Base("s3://", byte(match.Separator), match.Key),
+		cloudpath.Base("s3://", delim, key),
 		aws.ToInt64(head.ContentLength),
 		mode,
 		aws.ToTime(head.LastModified),
@@ -68,11 +97,12 @@ func objectStat(ctx context.Context, client Client, match cloudpath.Match) (file
 	return info, nil
 }
 
-func getObject(ctx context.Context, client Client, delim byte, name string) (cloudpath.Match, *s3.GetObjectOutput, error) {
-	match := cloudpath.AWSS3MatcherSep(name, delim)
+func getObject(ctx context.Context, client Client, delim byte, path string) (cloudpath.Match, *s3.GetObjectOutput, error) {
+	match := cloudpath.AWSS3MatcherSep(path, delim)
 	if len(match.Matched) == 0 {
-		return match, nil, fmt.Errorf("invalid s3 path: %v", name)
+		return match, nil, fmt.Errorf("invalid s3 path: %v", path)
 	}
+	fmt.Printf("GET %v -> %v\n", path, match.Key)
 	bucket := match.Volume
 	req := s3.GetObjectInput{
 		Bucket: aws.String(bucket),

--- a/aws/s3fs/s3ops.go
+++ b/aws/s3fs/s3ops.go
@@ -68,19 +68,21 @@ func listPrefix(ctx context.Context, client Client, bucket, key, delim, owner st
 	if len(res.Contents)+len(res.CommonPrefixes) == 0 {
 		return file.Info{}, &types.NotFound{}
 	}
-	return prefixFileInfo(key, delim[0]), nil
+	return prefixFileInfo(key, delim[0], owner), nil
 }
 
 func isPrefixKey(key string, delim byte) bool {
 	return len(key) > 0 && key[len(key)-1] == delim
 }
 
-func prefixFileInfo(key string, delim byte) file.Info {
+func prefixFileInfo(key string, delim byte, owner string) file.Info {
 	if lk := len(key); lk > 0 && key[lk-1] == delim {
 		key = key[:lk-1]
 	}
+	var xattr s3xattr
+	xattr.owner = owner
 	name := cloudpath.Base("s3://", delim, key) + string(delim)
-	return file.NewInfo(name, 0, fs.ModeDir, time.Time{}, nil)
+	return file.NewInfo(name, 0, fs.ModeDir, time.Time{}, xattr)
 }
 
 func ensureIsPrefix(prefix string, delim byte) string {

--- a/aws/s3fs/s3scanner.go
+++ b/aws/s3fs/s3scanner.go
@@ -36,6 +36,7 @@ func DirectoryBucketAZ(bucket string) string {
 var slashDelim = aws.String("/")
 
 func NewLevelScanner(client Client, delimiter byte, path string) filewalk.LevelScanner {
+	path = ensureIsPrefix(path, delimiter)
 	match := cloudpath.AWSS3MatcherSep(path, delimiter)
 	if len(match.Matched) == 0 {
 		return &scanner{err: fmt.Errorf("invalid s3 path: %v", path)}
@@ -55,7 +56,6 @@ func NewLevelScanner(client Client, delimiter byte, path string) filewalk.LevelS
 }
 
 func (fs *T) LevelScanner(prefix string) filewalk.LevelScanner {
-	prefix = fs.ensureIsPrefix(prefix)
 	return NewLevelScanner(fs.client, fs.options.delimiter, prefix)
 }
 


### PR DESCRIPTION
Improve handling of Stat for prefixes vs objects. If a path ends in / (or whatever delimiter is in use) then try it as a prefix first and then as an object. If path does not end in / then reverse the order, try head first and then as a prefix. The test for a valid prefix is simply to list the prefix and see if it has any contents.