### PR TITLE
errors: change Append to recognize errors.M and append the contained errors directly

### DIFF
--- a/errors/multi.go
+++ b/errors/multi.go
@@ -66,6 +66,10 @@ func (m *M) Append(errs ...error) {
 		if err == nil {
 			continue
 		}
+		if merr, ok := err.(*M); ok {
+			m.errs = append(m.errs, merr.errs...)
+			continue
+		}
 		m.errs = append(m.errs, err)
 	}
 }

--- a/errors/multi_test.go
+++ b/errors/multi_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -266,6 +267,37 @@ func TestSquashl(t *testing.T) {
   --- context canceled squashed 3 times`; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
+}
+
+func TestAppend(t *testing.T) {
+	m := &errors.M{}
+	m.Append(os.ErrExist)
+	m.Append(os.ErrInvalid)
+
+	n := &errors.M{}
+	n.Append(os.ErrExist)
+	n.Append(os.ErrInvalid)
+	m.Append(n)
+
+	m.Append(os.ErrExist)
+
+	all := []error{}
+	for {
+		e := m.Unwrap()
+		if e == nil {
+			break
+		}
+		all = append(all, e)
+	}
+
+	if got, want := len(all), 5; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	if !slices.Equal(all, []error{os.ErrExist, os.ErrInvalid, os.ErrExist, os.ErrInvalid, os.ErrExist}) {
+		t.Errorf("got %v, want %v", all, []error{os.ErrExist, os.ErrInvalid, os.ErrExist, os.ErrInvalid})
+	}
+
 }
 
 func ExampleM() {

--- a/errors/multi_test.go
+++ b/errors/multi_test.go
@@ -277,9 +277,7 @@ func TestAppend(t *testing.T) {
 	n := &errors.M{}
 	n.Append(os.ErrExist)
 	n.Append(os.ErrInvalid)
-	m.Append(n)
-
-	m.Append(os.ErrExist)
+	m.Append(n, os.ErrExist)
 
 	all := []error{}
 	for {

--- a/errors/multi_test.go
+++ b/errors/multi_test.go
@@ -244,16 +244,12 @@ func TestSquashl(t *testing.T) {
 	}
 
 	if got, want := m.Squash(context.Canceled).Error(), `  --- 1 of 3 errors
-    --- 1 of 2 errors
   context canceled
-  --- 2 of 2 errors
-  invalid argument
-  --- context canceled squashed 2 times
   --- 2 of 3 errors
-  file already exists
+  invalid argument
   --- 3 of 3 errors
-  context canceled
-  --- context canceled squashed 2 times`; got != want {
+  file already exists
+  --- context canceled squashed 4 times`; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 


### PR DESCRIPTION
Change M.Append() to recognize errors.M in its arguments and to append its contents directly.