### PR TITLE
file/content/stores: remove Stats methods

### DIFF
--- a/file/content/stores/async_test.go
+++ b/file/content/stores/async_test.go
@@ -67,6 +67,11 @@ func TestAsyncWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// It's safe to call Finish multiple times.
+	if err := store.Finish(); err != nil {
+		t.Fatal(err)
+	}
+
 	for i := 0; i < 100; i++ {
 		var obj content.Object[string, int]
 		ctype, err := obj.Load(ctx, store, prefix, fmt.Sprintf("c-%03v", i))

--- a/file/content/stores/ops.go
+++ b/file/content/stores/ops.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"sync/atomic"
 
 	"cloudeng.io/file/content"
 	"cloudeng.io/file/content/internal"
@@ -21,7 +20,7 @@ func eraseExisting(ctx context.Context, fs content.FS, root string) error {
 	return nil
 }
 
-func read(ctx context.Context, fs content.FS, path string, readCnt *int64) (content.Type, []byte, error) {
+func read(ctx context.Context, fs content.FS, path string) (content.Type, []byte, error) {
 	buf, err := fs.Get(ctx, path)
 	if err != nil {
 		return "", nil, err
@@ -31,11 +30,10 @@ func read(ctx context.Context, fs content.FS, path string, readCnt *int64) (cont
 	if err != nil {
 		return "", nil, err
 	}
-	atomic.AddInt64(readCnt, 1)
 	return content.Type(typ), buf, nil
 }
 
-func write(ctx context.Context, fs content.FS, prefix, name string, data []byte, writtenCnt *int64) error {
+func write(ctx context.Context, fs content.FS, prefix, name string, data []byte) error {
 	path := fs.Join(prefix, name)
 	if err := fs.Put(ctx, path, 0600, data); err != nil {
 		if !fs.IsNotExist(err) {
@@ -48,6 +46,5 @@ func write(ctx context.Context, fs content.FS, prefix, name string, data []byte,
 			return err
 		}
 	}
-	atomic.AddInt64(writtenCnt, 1)
 	return nil
 }

--- a/file/content/stores/store_test.go
+++ b/file/content/stores/store_test.go
@@ -61,14 +61,6 @@ func TestStore(t *testing.T) {
 	}
 	path := fs.Join(root, prefix, "c")
 
-	read, written := store.Stats()
-	if got, want := read, int64(0); got != want {
-		t.Errorf("got %v, want %v", got, want)
-	}
-	if got, want := written, int64(1); got != want {
-		t.Errorf("got %v, want %v", got, want)
-	}
-
 	if _, err := fs.Stat(ctx, path); err != nil {
 		t.Fatal(err)
 	}
@@ -82,14 +74,6 @@ func TestStore(t *testing.T) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 	if got, want := obj1, obj; !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
-	}
-
-	read, written = store.Stats()
-	if got, want := read, int64(1); got != want {
-		t.Errorf("got %v, want %v", got, want)
-	}
-	if got, want := written, int64(1); got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
 

--- a/file/content/stores/sync.go
+++ b/file/content/stores/sync.go
@@ -6,7 +6,6 @@ package stores
 
 import (
 	"context"
-	"sync/atomic"
 
 	"cloudeng.io/file/content"
 )
@@ -15,9 +14,7 @@ import (
 // content.ObjectStore. It uses an instance of content.FS to store and
 // retrieve objects.
 type Sync struct {
-	fs      content.FS
-	written int64
-	read    int64
+	fs content.FS
 }
 
 // New returns a new instance of Sync backed by the supplied
@@ -42,16 +39,10 @@ func (s *Sync) FS() content.FS {
 // from the store. The caller is responsible for using the returned type to
 // decode the data into an appropriate object.
 func (s *Sync) Read(ctx context.Context, prefix, name string) (content.Type, []byte, error) {
-	return read(ctx, s.fs, s.fs.Join(prefix, name), &s.read)
+	return read(ctx, s.fs, s.fs.Join(prefix, name))
 }
 
 // Write stores the data at the specified prefix and name in the store.
 func (s *Sync) Write(ctx context.Context, prefix, name string, data []byte) error {
-	return write(ctx, s.fs, prefix, name, data, &s.written)
-}
-
-// Stats returns the number of objects read and written to the store
-// since this instance was created.
-func (s *Sync) Stats() (read, written int64) {
-	return atomic.LoadInt64(&s.read), atomic.LoadInt64(&s.written)
+	return write(ctx, s.fs, prefix, name, data)
 }

--- a/file/crawl/crawlcmd/crawlcmd.go
+++ b/file/crawl/crawlcmd/crawlcmd.go
@@ -149,8 +149,8 @@ func (c Crawler) saveCrawled(ctx context.Context, root, name string, crawledCh c
 	sharder := path.NewSharder(path.WithSHA1PrefixLength(c.Cache.ShardingPrefixLen))
 	join := c.cache.FS().Join
 
+	written := 0
 	defer func() {
-		_, written := c.cache.Stats()
 		log.Printf("total written: %v", written)
 	}()
 
@@ -176,7 +176,8 @@ func (c Crawler) saveCrawled(ctx context.Context, root, name string, crawledCh c
 				log.Printf("failed to write: %v as prefix: %v, suffix: %v: %v\n", dld.Name, prefix, suffix, err)
 				continue
 			}
-			if _, written := c.cache.Stats(); written%100 == 0 {
+			written++
+			if written%100 == 0 {
 				log.Printf("written: %v", written)
 			}
 		}


### PR DESCRIPTION
The Stats() method has turned out to not be broadly used since many crawlers/indexers use multiple stores and hence track stats separately.