### PR TITLE
file/localfs: make async directory open in level scanner optional

### DIFF
--- a/file/localfs/localfs.go
+++ b/file/localfs/localfs.go
@@ -10,18 +10,37 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"time"
 
 	"cloudeng.io/file"
 )
 
 // T represents the local filesystem. It implements FS, ObjectFS
 // and filewalk.FS
-type T struct{}
+type T struct {
+	opts options
+}
+
+type Option func(o *options)
+
+type options struct {
+	scannerOpenWait time.Duration
+}
+
+func WithScannerOpenWait(d time.Duration) Option {
+	return func(o *options) {
+		o.scannerOpenWait = d
+	}
+}
 
 // NewLocalFS returns an instance of file.FS that provides access to the
 // local filesystem.
-func New() *T {
-	return &T{}
+func New(opts ...Option) *T {
+	t := &T{}
+	for _, fn := range opts {
+		fn(&t.opts)
+	}
+	return t
 }
 
 func (f *T) Open(name string) (fs.File, error) {

--- a/file/localfs/localfs_test.go
+++ b/file/localfs/localfs_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"os"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -80,20 +79,5 @@ func TestSetXAttr(t *testing.T) {
 
 	if got, want := fi.Sys(), x; !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
-	}
-}
-
-func TestWait(t *testing.T) {
-	tmpdir := t.TempDir()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
-	defer cancel()
-	fs := localfs.New(localfs.WithScannerOpenWait(time.Nanosecond))
-	sc := fs.LevelScanner(tmpdir)
-	if sc.Scan(ctx, 1) {
-		t.Errorf("expected scan to fail")
-	}
-	err := sc.Err()
-	if err == nil || !strings.Contains(err.Error(), "took too long") {
-		t.Errorf("missing or wrong error: %v", err)
 	}
 }

--- a/file/localfs/localfs_test.go
+++ b/file/localfs/localfs_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -79,5 +80,20 @@ func TestSetXAttr(t *testing.T) {
 
 	if got, want := fi.Sys(), x; !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestWait(t *testing.T) {
+	tmpdir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	fs := localfs.New(localfs.WithScannerOpenWait(time.Nanosecond))
+	sc := fs.LevelScanner(tmpdir)
+	if sc.Scan(ctx, 1) {
+		t.Errorf("expected scan to fail")
+	}
+	err := sc.Err()
+	if err == nil || !strings.Contains(err.Error(), "took too long") {
+		t.Errorf("missing or wrong error: %v", err)
 	}
 }

--- a/file/localfs/localfs_unix_test.go
+++ b/file/localfs/localfs_unix_test.go
@@ -8,8 +8,10 @@ package localfs_test
 
 import (
 	"context"
+	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"cloudeng.io/file"
 	"cloudeng.io/file/localfs"
@@ -56,5 +58,21 @@ func TestMergeXAttr(t *testing.T) {
 	}
 	if got, want := stat.Blksize, osStat.Blksize; got != want {
 		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestWait(t *testing.T) {
+	tmpdir := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	// Impossibly short timeout.
+	fs := localfs.New(localfs.WithScannerOpenWait(time.Nanosecond))
+	sc := fs.LevelScanner(tmpdir)
+	if sc.Scan(ctx, 1) {
+		t.Errorf("expected scan to fail")
+	}
+	err := sc.Err()
+	if err == nil || !strings.Contains(err.Error(), "took too long") {
+		t.Errorf("missing or wrong error: %v", err)
 	}
 }


### PR DESCRIPTION
The directory scanner can defend and report slow opens which typically occur when accessing cloud-backed local filesystems (eg. on macos with Library/Cloudstorage). However, doing so comes at the cost of creating a goroutine/timer/channel combination which can consume a lot of memory on fast or large filesystems leading to lots of GC churn which can in turn lead to memory exhaustion. This PR allows for this behaviour to be optionally configured rather than on by default.