### PR TITLE
cmdutil: adda convenience functions

### DIFF
--- a/cmdutil/subcmd/dispatch.go
+++ b/cmdutil/subcmd/dispatch.go
@@ -1,0 +1,30 @@
+// Copyright 2025 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+package subcmd
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"cloudeng.io/cmdutil"
+)
+
+var errInterrupt = errors.New("interrupt")
+
+// Dispatch runs the supplied CommandSetYAML with support for signal handling.
+// It will exit with an error if the context is cancelled with an interrupt
+// signal or if the CommandSetYAML returns an error.
+func Dispath(ctx context.Context, cli *CommandSetYAML) {
+	ctx, cancel := context.WithCancelCause(ctx)
+	cmdutil.HandleSignals(func() { cancel(errInterrupt) }, os.Interrupt)
+	err := cli.Dispatch(ctx)
+	if context.Cause(ctx) == errInterrupt {
+		cmdutil.Exit("%v", errInterrupt)
+	}
+	if err != nil {
+		cmdutil.Exit("%v", err)
+	}
+}

--- a/cmdutil/subcmd/dispatch.go
+++ b/cmdutil/subcmd/dispatch.go
@@ -17,7 +17,7 @@ var errInterrupt = errors.New("interrupt")
 // Dispatch runs the supplied CommandSetYAML with support for signal handling.
 // It will exit with an error if the context is cancelled with an interrupt
 // signal or if the CommandSetYAML returns an error.
-func Dispath(ctx context.Context, cli *CommandSetYAML) {
+func Dispatch(ctx context.Context, cli *CommandSetYAML) {
 	ctx, cancel := context.WithCancelCause(ctx)
 	cmdutil.HandleSignals(func() { cancel(errInterrupt) }, os.Interrupt)
 	err := cli.Dispatch(ctx)

--- a/cmdutil/subcmd/yaml.go
+++ b/cmdutil/subcmd/yaml.go
@@ -49,8 +49,13 @@ type commandDef struct {
 type CommandSetYAML struct {
 	*CommandSet
 
+	spec       string
 	extensions []Extension
 	cmdDict    map[string]*Command
+}
+
+func (c *CommandSetYAML) String() string {
+	return c.spec
 }
 
 type CurrentCommand struct {
@@ -148,6 +153,7 @@ func FromYAML(spec []byte) (*CommandSetYAML, error) {
 		cmdSet.CommandSet = NewCommandSet(tlcmd)
 		cmdSet.cmd = tlcmd
 	}
+	cmdSet.spec = string(spec)
 	return cmdSet, nil
 }
 


### PR DESCRIPTION
- cmdutil.Dispatch function, a main function can now call Dispatch to run the CLI, handle signals etc.
- subcmd.CommandSetYAML.String() to display the yaml, possibly expanded with extensions, spec.